### PR TITLE
List page/#27 bottom sheet publishing

### DIFF
--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -11,78 +11,55 @@ interface FilterBottomProps {
 }
 
 const FilterBottom = ({isSortOpen, setSortOpen, isGenreOpen, setGenreOpen, isStyleOpen, setStyleOpen} : FilterBottomProps) => {
-    const SORT = ['인기 순', '가격 낮은 순', '가격 높은 순'];
-    const GENRE = ['일러스트', '동양화', '블랙워크', '라인 타투', '레터링', '수채화'];
-    const STYLE = ['추상적인', '심플한','귀여운', '사실적인', '감성적인', '다크한'];
 
+    const FILTER = [
+        {
+            type : '정렬',
+            isOpen : isSortOpen,
+            onClose : () => setSortOpen(false),
+            data : ['인기 순', '가격 낮은 순', '가격 높은 순']
+        },
+        {
+            type : '장르',
+            isOpen : isGenreOpen,
+            onClose : () => setGenreOpen(false),
+            data : ['일러스트', '동양화', '블랙워크', '라인 타투', '레터링', '수채화']
+        },
+        {
+            type : '스타일',
+            isOpen : isStyleOpen,
+            onClose : () => setStyleOpen(false),
+            data : ['추상적인', '심플한','귀여운', '사실적인', '감성적인', '다크한']
+        },
+
+    ]
 
     return (
         <>
-            <CustomSheet 
-                isOpen={isSortOpen} 
-                onClose={() => setSortOpen(false)}
-                detent="content-height"
-                disableDrag={true}
-                >
-                <Sheet.Container>
-                <Sheet.Header disableDrag={true}/>
-                <Sheet.Content>
-                    {SORT.map((el)=>(
-                        <St.TagBox key={el}>{el}</St.TagBox>
-                    ))}
-                    <St.Footer>
-                        <St.Button type='button'>
-                            적용하기
-                        </St.Button>
-                    </St.Footer>
-                </Sheet.Content>
-                </Sheet.Container>
-                <Sheet.Backdrop onClick={() => setSortOpen(false)}/>
-            </CustomSheet>
-
-            <CustomSheet 
-                isOpen={isGenreOpen} 
-                onClose={() => setGenreOpen(false)}
-                detent="content-height"
-                disableDrag={true}
-                >
-                <Sheet.Container>
-                    <Sheet.Header disableDrag={true}/>
-                    <Sheet.Content>
-                        {GENRE.map((el)=>(
-                            <St.TagBox key={el}>{el}</St.TagBox>
-                        ))}
-                        <St.Footer>
-                            <St.Button type='button'>
-                                적용하기
-                            </St.Button>
-                        </St.Footer>
-                    </Sheet.Content>
-                </Sheet.Container>
-                <Sheet.Backdrop onClick={() => setGenreOpen(false)}/>
-            </CustomSheet>
-
-            <CustomSheet 
-                isOpen={isStyleOpen} 
-                onClose={() => setStyleOpen(false)}
-                detent="content-height"
-                disableDrag={true}
-                >
-                <Sheet.Container>
-                <Sheet.Header disableDrag={true}/>
-                <Sheet.Content>
-                    {STYLE.map((el)=>(
-                        <St.TagBox key={el}>{el}</St.TagBox>
-                    ))}
-                    <St.Footer>
-                        <St.Button type='button'>
-                            적용하기
-                        </St.Button>
-                    </St.Footer>
-                </Sheet.Content>
-                </Sheet.Container>
-                <Sheet.Backdrop onClick={() => setStyleOpen(false)}/>
-            </CustomSheet>
+            {FILTER.map((filter)=>(
+                <CustomSheet 
+                    key={filter.type}
+                    isOpen={filter.isOpen} 
+                    onClose={filter.onClose}
+                    detent="content-height"
+                    disableDrag={true}
+                    >
+                    <Sheet.Container>
+                        <Sheet.Header disableDrag={true}/>
+                        <Sheet.Content>
+                            {filter.data.map((el)=>(
+                                <St.TagBox key={el}>{el}</St.TagBox>
+                            ))}
+                            <St.Footer>
+                                <St.Button type='button'>
+                                    적용하기
+                                </St.Button>
+                            </St.Footer>
+                        </Sheet.Content>
+                    </Sheet.Container>
+                    <Sheet.Backdrop onClick={filter.onClose}/>
+                </CustomSheet>
+            ))}
         </>
 
     )

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -1,9 +1,26 @@
 import styled from "styled-components"
+import Sheet from 'react-modal-sheet';
+import { useState } from 'react';
 
 const FilterBottom = () => {
-  return (
-    <div>FilterBottom</div>
-  )
+    const [isOpen, setOpen] = useState(false);
+
+    return (
+        <>
+        <button onClick={() => setOpen(true)}>Open sheet</button>
+        <Sheet isOpen={isOpen} onClose={() => setOpen(false)}>
+            <Sheet.Container>
+            <Sheet.Header />
+            <Sheet.Content>
+
+            </Sheet.Content>
+            </Sheet.Container>
+            <Sheet.Backdrop />
+        </Sheet>
+        </>
+
+
+    )
 }
 
 export default FilterBottom

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -8,7 +8,12 @@ const FilterBottom = () => {
     return (
         <>
         <button onClick={() => setOpen(true)}>Open sheet</button>
-        <Sheet isOpen={isOpen} onClose={() => setOpen(false)}>
+        <Sheet 
+            isOpen={isOpen} 
+            onClose={() => setOpen(false)}
+            detent="content-height"
+            disableDrag={true}
+            >
             <Sheet.Container>
             <Sheet.Header />
             <Sheet.Content>

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -1,18 +1,27 @@
 import styled from "styled-components"
 import Sheet from 'react-modal-sheet';
-import { useState } from 'react';
 
-const FilterBottom = () => {
+interface FilterBottomProps {
+    isSortOpen : boolean;
+    setSortOpen : React.Dispatch<React.SetStateAction<boolean>>,
+    isGenreOpen : boolean;
+    setGenreOpen : React.Dispatch<React.SetStateAction<boolean>>,
+    isStyleOpen : boolean;
+    setStyleOpen : React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const FilterBottom = ({isSortOpen, setSortOpen, isGenreOpen, setGenreOpen, isStyleOpen, setStyleOpen} : FilterBottomProps) => {
     const SORT = ['인기 순', '가격 낮은 순', '가격 높은 순'];
-    const [isOpen, setOpen] = useState(false);
+    const GENRE = ['일러스트', '동양화', '블랙워크', '라인 타투', '레터링', '수채화'];
+    const STYLE = ['추상적인', '심플한','귀여운', '사실적인', '감성적인', '다크한'];
 
 
     return (
         <>
-            <button onClick={() => setOpen(true)}>Open sheet</button>
+            <button onClick={() => setSortOpen(true)}>Open sheet</button>
             <CustomSheet 
-                isOpen={isOpen} 
-                onClose={() => setOpen(false)}
+                isOpen={isSortOpen} 
+                onClose={() => setSortOpen(false)}
                 detent="content-height"
                 disableDrag={true}
                 >
@@ -29,7 +38,51 @@ const FilterBottom = () => {
                     </St.Footer>
                 </Sheet.Content>
                 </Sheet.Container>
-                <Sheet.Backdrop onClick={() => setOpen(false)}/>
+                <Sheet.Backdrop onClick={() => setSortOpen(false)}/>
+            </CustomSheet>
+
+            <CustomSheet 
+                isOpen={isGenreOpen} 
+                onClose={() => setGenreOpen(false)}
+                detent="content-height"
+                disableDrag={true}
+                >
+                <Sheet.Container>
+                <Sheet.Header disableDrag={true}/>
+                <Sheet.Content>
+                    {GENRE.map((el)=>(
+                        <St.TagBox key={el}>{el}</St.TagBox>
+                    ))}
+                    <St.Footer>
+                        <St.Button type='button'>
+                            적용하기
+                        </St.Button>
+                    </St.Footer>
+                </Sheet.Content>
+                </Sheet.Container>
+                <Sheet.Backdrop onClick={() => setGenreOpen(false)}/>
+            </CustomSheet>
+
+            <CustomSheet 
+                isOpen={isStyleOpen} 
+                onClose={() => setStyleOpen(false)}
+                detent="content-height"
+                disableDrag={true}
+                >
+                <Sheet.Container>
+                <Sheet.Header disableDrag={true}/>
+                <Sheet.Content>
+                    {STYLE.map((el)=>(
+                        <St.TagBox key={el}>{el}</St.TagBox>
+                    ))}
+                    <St.Footer>
+                        <St.Button type='button'>
+                            적용하기
+                        </St.Button>
+                    </St.Footer>
+                </Sheet.Content>
+                </Sheet.Container>
+                <Sheet.Backdrop onClick={() => setStyleOpen(false)}/>
             </CustomSheet>
         </>
 

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -3,29 +3,80 @@ import Sheet from 'react-modal-sheet';
 import { useState } from 'react';
 
 const FilterBottom = () => {
+    const SORT = ['인기 순', '가격 낮은 순', '가격 높은 순'];
     const [isOpen, setOpen] = useState(false);
+
 
     return (
         <>
-        <button onClick={() => setOpen(true)}>Open sheet</button>
-        <Sheet 
-            isOpen={isOpen} 
-            onClose={() => setOpen(false)}
-            detent="content-height"
-            disableDrag={true}
-            >
-            <Sheet.Container>
-            <Sheet.Header />
-            <Sheet.Content>
-
-            </Sheet.Content>
-            </Sheet.Container>
-            <Sheet.Backdrop />
-        </Sheet>
+            <button onClick={() => setOpen(true)}>Open sheet</button>
+            <CustomSheet 
+                isOpen={isOpen} 
+                onClose={() => setOpen(false)}
+                detent="content-height"
+                disableDrag={true}
+                >
+                <Sheet.Container>
+                <Sheet.Header disableDrag={true}/>
+                <Sheet.Content>
+                    {SORT.map((el)=>(
+                        <St.TagBox key={el}>{el}</St.TagBox>
+                    ))}
+                    <St.Footer>
+                        <St.Button type='button'>
+                            적용하기
+                        </St.Button>
+                    </St.Footer>
+                </Sheet.Content>
+                </Sheet.Container>
+                <Sheet.Backdrop />
+            </CustomSheet>
         </>
-
 
     )
 }
 
 export default FilterBottom
+
+const St = {
+    TagBox : styled.p`
+        text-align: center;
+
+        width:100%;
+        padding: 1.7rem 0rem;
+        color: ${({ theme }) => theme.colors.gray4};
+        ${({ theme }) => theme.fonts.title_medium_18};
+    `,
+    Footer: styled.footer`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 7rem;
+        margin-top: 4rem;
+
+        background-color: ${({ theme }) => theme.colors.gray3};
+    `,
+    Button: styled.button`
+        width: 100%;
+        height: 100%;
+
+        color: ${({ theme }) => theme.colors.white};
+        font: ${({ theme }) => theme.fonts.title_semibold_18};
+    `,
+}
+
+const CustomSheet = styled(Sheet)`
+    .react-modal-sheet-backdrop {
+        background-color: rgba(0, 0, 0, 0.6) !important;
+    }
+    .react-modal-sheet-container {
+        border-radius: 1rem !important;
+    }
+    .react-modal-sheet-header {
+        height: 1.6rem !important;
+    }
+    .react-modal-sheet-drag-indicator {
+        display: none;
+    }
+`;

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -18,7 +18,6 @@ const FilterBottom = ({isSortOpen, setSortOpen, isGenreOpen, setGenreOpen, isSty
 
     return (
         <>
-            <button onClick={() => setSortOpen(true)}>Open sheet</button>
             <CustomSheet 
                 isOpen={isSortOpen} 
                 onClose={() => setSortOpen(false)}

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components"
+
+const FilterBottom = () => {
+  return (
+    <div>FilterBottom</div>
+  )
+}
+
+export default FilterBottom

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -47,17 +47,17 @@ const FilterBottom = ({isSortOpen, setSortOpen, isGenreOpen, setGenreOpen, isSty
                 disableDrag={true}
                 >
                 <Sheet.Container>
-                <Sheet.Header disableDrag={true}/>
-                <Sheet.Content>
-                    {GENRE.map((el)=>(
-                        <St.TagBox key={el}>{el}</St.TagBox>
-                    ))}
-                    <St.Footer>
-                        <St.Button type='button'>
-                            적용하기
-                        </St.Button>
-                    </St.Footer>
-                </Sheet.Content>
+                    <Sheet.Header disableDrag={true}/>
+                    <Sheet.Content>
+                        {GENRE.map((el)=>(
+                            <St.TagBox key={el}>{el}</St.TagBox>
+                        ))}
+                        <St.Footer>
+                            <St.Button type='button'>
+                                적용하기
+                            </St.Button>
+                        </St.Footer>
+                    </Sheet.Content>
                 </Sheet.Container>
                 <Sheet.Backdrop onClick={() => setGenreOpen(false)}/>
             </CustomSheet>

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -29,7 +29,7 @@ const FilterBottom = () => {
                     </St.Footer>
                 </Sheet.Content>
                 </Sheet.Container>
-                <Sheet.Backdrop />
+                <Sheet.Backdrop onClick={() => setOpen(false)}/>
             </CustomSheet>
         </>
 

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -2,7 +2,13 @@ import styled from "styled-components";
 import { IcDownArrow } from "../../assets/icon";
 import { useState } from "react";
 
-const TattooList = () => {
+interface TattooListProps {
+  setSortOpen : React.Dispatch<React.SetStateAction<boolean>>,
+  setGenreOpen : React.Dispatch<React.SetStateAction<boolean>>,
+  setStyleOpen : React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const TattooList = ({setSortOpen, setGenreOpen, setStyleOpen} : TattooListProps) => {
   const BUTTON = ['정렬','장르','스타일'];
   const [count,setCount] = useState(17);
   const TATTOO_LIST = [

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -31,7 +31,19 @@ const TattooList = ({setSortOpen, setGenreOpen, setStyleOpen} : TattooListProps)
       <St.Header>ALL</St.Header>
       <St.BtnContainer>
         {BUTTON.map((el)=>(
-          <St.FilterBtn key={el}>
+          <St.FilterBtn key={el} onClick={()=>{
+            switch (el) {
+              case '정렬':
+                setSortOpen(true);
+                break;
+              case '장르':
+                setGenreOpen(true);
+                break;
+              case '스타일':
+                setStyleOpen(true);
+                break;
+            }
+          }}>
             {el}
             <IcDownArrow/>
           </St.FilterBtn>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -1,14 +1,27 @@
 import FilterBottom from "../components/List/FilterBottom";
 import TattooList from "../components/List/TattooList";
 import styled from "styled-components";
+import { useState } from 'react';
 
 const ListPage = () => {
+  const [isSortOpen, setSortOpen] = useState(false);
+  const [isGenreOpen, setGenreOpen] = useState(false);
+  const [isStyleOpen, setStyleOpen] = useState(false);
+
   return (
     <div>
         ListPage
         <St.Line/>
-        <TattooList/>
-        <FilterBottom/>
+        <TattooList
+          setSortOpen={setSortOpen}
+          setGenreOpen={setGenreOpen}
+          setStyleOpen={setStyleOpen}
+        />
+        <FilterBottom
+          isSortOpen={isSortOpen} setSortOpen={setSortOpen}
+          isGenreOpen={isGenreOpen} setGenreOpen={setGenreOpen}
+          isStyleOpen={isStyleOpen} setStyleOpen={setStyleOpen}
+        />
     </div>
   )
 }

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -1,3 +1,4 @@
+import FilterBottom from "../components/List/FilterBottom";
 import TattooList from "../components/List/TattooList";
 import styled from "styled-components";
 
@@ -7,6 +8,7 @@ const ListPage = () => {
         ListPage
         <St.Line/>
         <TattooList/>
+        <FilterBottom/>
     </div>
   )
 }


### PR DESCRIPTION
## 🔥 Related Issues
resolved #27 

## 💜 작업 내용
- [x] Bottom 시트 라이브러리 사용 + 커스텀 
- [x] 정렬 / 장르 / 스타일 버튼 클릭 시 바텀시트 등장 
- [x] 바텀시트 배경 클릭 시 바텀시트 내려감 

## ✅ PR Point
- `CustomSheet` : 라이브러리 사용과 동시에 커스터마이징 하기 위해 
- 바텀시트 내 모든 항목은 상수배열로 관리하여 mapping 
- 세 종류의 바텀시트를 열고 닫는 state를 상단인 'ListPage'에서 관리함 
  - 바텀시트 컴포넌트와 타투리스트 컴포넌트에 state props로 전달 
  - 타투 리스트에 있는 필터 버튼 클릭 시 바텀시트 state를 toggle 하기 위해서

- 참고로 바텀시트 내에 항목을 선택하고, 적용하기 누르면 바텀시트 내려가고 해당 항목으로 버튼 형태 바뀌는건 다음 이슈에서 다룰 예정 

## ☀️ 화면 녹화 

- 디코로 노래 듣던거 다 담겻네요 ㅋㅋ 무시부탁

https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/321caf36-c0f4-4f07-a381-51cc7ca8b049

