### PR TITLE
[Common] progress bar 구현

### DIFF
--- a/src/common/ProgressBar.tsx
+++ b/src/common/ProgressBar.tsx
@@ -1,0 +1,38 @@
+import { styled } from 'styled-components';
+
+interface ProgressBarProps {
+  // 현재 단계 (전체 페이지에 비례하는 단계)
+  curStep: number;
+  // 전체 페이지 수
+  maxStep: number;
+}
+
+const ProgressBar = ({ curStep, maxStep }: ProgressBarProps) => {
+  return (
+    <St.ProgressBarWrapper>
+      <progress value={(curStep)} max={maxStep}></progress>
+    </St.ProgressBarWrapper>
+  );
+};
+
+const St = {
+  ProgressBarWrapper: styled.div`
+    & > progress {
+      width: 100%;
+      height: 0.4rem;
+
+      color: ${({ theme }) => theme.colors.pink5};
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    & > progress::-webkit-progress-bar {
+      background-color: ${({ theme }) => theme.colors.gray1};
+    }
+    & > progress::-webkit-progress-value {
+      background-color: ${({ theme }) => theme.colors.pink5};
+    }
+  `,
+};
+
+export default ProgressBar;

--- a/src/common/ProgressBar.tsx
+++ b/src/common/ProgressBar.tsx
@@ -10,7 +10,7 @@ interface ProgressBarProps {
 const ProgressBar = ({ curStep, maxStep }: ProgressBarProps) => {
   return (
     <St.ProgressBarWrapper>
-      <progress value={(curStep)} max={maxStep}></progress>
+      <progress value={curStep} max={maxStep}></progress>
     </St.ProgressBarWrapper>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,11 +9,15 @@ interface HeaderProps {
 
 const Header = ({ leftSection, title, rightSection, transparent }: HeaderProps) => {
   return (
-    <St.header transparent={transparent}>
-      {leftSection}
-      {title && <St.title>{title}</St.title>}
-      {rightSection}
-    </St.header>
+    <>
+      <St.header transparent={transparent}>
+        {leftSection}
+        {title && <St.title>{title}</St.title>}
+        {rightSection}
+      </St.header>
+      {/* 여기에 프로그레스바 추가 (아래처럼 쓰면 됨)*/}
+      {/* <ProgressBar curStep={2} maxStep={5} /> */}
+    </>
   );
 };
 


### PR DESCRIPTION
## 🔥 Related Issues
resolved #63 

## 💜 작업 내용
- [x] progress bar 구현

<br />

## ✅ PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
    1. <progress> 태그를 활용해서 구현했습니다.
    2. value: 전체 페이지에 비례하는 현재 단계
    3. max: 전체 페이지 수
    ```
    <St.ProgressBarWrapper>
      <progress value={curStep} max={maxStep}></progress>
    </St.ProgressBarWrapper>
    ```
    4. props로 value와 max를 넘겨주면 재사용할 수 있습니다.
    ```
    <ProgressBar curStep={2} maxStep={5} />
    ```

<br />

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="378" alt="스크린샷 2023-07-10 오후 11 15 17" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/42162e4c-b6a2-4cf5-80cb-0b76d76668c2">
