### PR TITLE
style: 체크 위치 이슈 수정

### DIFF
--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -3,7 +3,6 @@ import Sheet from 'react-modal-sheet';
 import { useRef, useState } from "react";
 import ic_check_small_light from '../../assets/icon/ic_check_small_light.svg';
 import ic_check_small_pink from '../../assets/icon/ic_check_small_pink.svg';
-import { IcCheckSmallLight } from "../../assets/icon";
 
 interface FilterBottomProps {
     isSortOpen : boolean;

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -140,7 +140,7 @@ const St = {
         height: 100%;
 
         color: ${({ theme }) => theme.colors.white};
-        font: ${({ theme }) => theme.fonts.title_semibold_18};
+        ${({ theme }) => theme.fonts.title_semibold_18};
     `,
 }
 

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -1,6 +1,9 @@
 import styled from "styled-components"
 import Sheet from 'react-modal-sheet';
 import { useRef, useState } from "react";
+import ic_check_small_light from '../../assets/icon/ic_check_small_light.svg';
+import ic_check_small_pink from '../../assets/icon/ic_check_small_pink.svg';
+import { IcCheckSmallLight } from "../../assets/icon";
 
 interface FilterBottomProps {
     isSortOpen : boolean;
@@ -65,7 +68,11 @@ const FilterBottom = ({isSortOpen, setSortOpen, isGenreOpen, setGenreOpen, isSty
                                 <St.TagBox 
                                     key={el}
                                     onClick={()=>handleClickTag(idx)}
-                                    >{el}</St.TagBox>
+                                    >
+                                    <span></span>
+                                    {el}
+                                    <i></i>
+                                </St.TagBox>
                             ))}
                             <St.Footer $sel={isSelected}>
                                 <St.Button type='button'>
@@ -91,19 +98,32 @@ const St = {
         color: ${({ theme }) => theme.colors.gray4};
         ${({ theme }) => theme.fonts.title_medium_18};
 
+        & > span {
+            display: inline-block;
+            vertical-align: middle;
+            margin: 0rem 0.3rem;
+            width: 2rem;
+            height: 2rem;
+        }
+
+        & > i {
+            display: inline-block;
+            vertical-align: middle;
+            margin: 0rem 0.3rem;
+            width: 2rem;
+            height: 2rem;
+
+            background: url(${ic_check_small_light});
+        }
+
         &.select {
             color: ${({ theme }) => theme.colors.gray8};
             ${({ theme }) => theme.fonts.title_semibold_18};
 
-            &::after {
-                display: inline-block;
-                vertical-align: middle;
-                margin-left: 0.3rem;
-                width: 2rem;
-                height: 2rem;
-                background-image: url('/src/assets/icon/ic_check_small_pink.svg');   //component로 하는 방법을 찾지 못함
-                content: '';
+            & > i {
+                background: url(${ic_check_small_pink});
             }
+
         }
     `,
     Footer: styled.footer<{$sel : boolean}>`

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 import Sheet from 'react-modal-sheet';
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import ic_check_small_light from '../../assets/icon/ic_check_small_light.svg';
 import ic_check_small_pink from '../../assets/icon/ic_check_small_pink.svg';
 
@@ -18,6 +18,10 @@ const FilterBottom = ({isSortOpen, setSortOpen, isGenreOpen, setGenreOpen, isSty
     const filterRef = useRef<HTMLElement>(null);
     const [isSelected, setSelected] = useState(false);
 
+    useEffect(() => {
+        setSelected(false);
+    }, [isSortOpen, isGenreOpen, isStyleOpen])
+    
     const FILTER = [
         {
             type : '정렬',

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import { IcArrowBottomSmallGray } from "../../assets/icon";
 import { useState } from "react";
-import { IcDownArrow } from "../../assets/icon";
 
 interface TattooListProps {
   setSortOpen : React.Dispatch<React.SetStateAction<boolean>>,


### PR DESCRIPTION
## 🔥 Related Issues
resolved #98 

## 💜 작업 내용
- [x] 체크 표시 위치를 맞추기 위해 조절

## ✅ PR Point
- 노가다 이슈
- 그 외 Footer 버튼이 BottomSheet 껐다가 다시 켰을 때 비활성화되지 않고, 계속 활성화되어있던 이슈가 있었는데, useEffect 사용해서 해결했습니다! 

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/e4f3a54c-1fc7-40e8-8a9a-aca37f87aa14

