### PR TITLE
[CustomImgPage] 그려둔 이미지 도안 첨부 UI 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,6 +3,7 @@ import MainPage from './pages/MainPage';
 import LoginPage from './pages/Login/LoginPage';
 import RegisterPage from './pages/Register/RegisterPage';
 import RegisterPhoneNum from './components/Register/RegisterPhoneNum';
+import CustomImgPage from './pages/Custom/NoDesign/CustomImgPage';
 
 const Router = () => {
   return (
@@ -12,6 +13,7 @@ const Router = () => {
         <Route path='/login' element={<LoginPage />} />
         <Route path='/register' element={<RegisterPage />} />
         <Route path='/input-number' element={<RegisterPhoneNum />} />
+        <Route path='/custom-img' element={<CustomImgPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -1,5 +1,114 @@
+import { styled } from 'styled-components';
+import { IcCheckSmallGray, IcPhoto } from '../../../assets/icon';
+
 const CustomImg = () => {
-  return <div>이미지 추가추가</div>;
+  return (
+    <St.CustomImgWrapper>
+      <St.ImgInfoContainer>
+        <St.ImgInfoTitle>그려둔 도안 이미지를 첨부해주세요</St.ImgInfoTitle>
+        <St.ImgInfoDetail>
+          <IcCheckSmallGray />
+          <span>선택 크기보다 0cm 이상 여유 있는 크기로 첨부해주세요</span>
+        </St.ImgInfoDetail>
+        <St.ImgInfoDetail>
+          <IcCheckSmallGray />
+          <span>투명한 배경, 고화질 png 파일로 1장 첨부해주세요</span>
+        </St.ImgInfoDetail>
+      </St.ImgInfoContainer>
+      <St.ImgAttachContainer>
+        <St.ImgAttachArea>
+          <p>도안 이미지를 첨부해주세요</p>
+        </St.ImgAttachArea>
+        <St.ImgAttachBtn type='button'>
+          <IcPhoto />
+          <span>사진 첨부하기</span>
+        </St.ImgAttachBtn>
+      </St.ImgAttachContainer>
+    </St.CustomImgWrapper>
+  );
 };
 
 export default CustomImg;
+
+const St = {
+  CustomImgWrapper: styled.section`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  `,
+
+  ImgInfoContainer: styled.article`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    margin: 5.6rem 0 3.6rem;
+  `,
+
+  ImgInfoTitle: styled.h2`
+    margin-bottom: 0.9rem;
+
+    color: ${({ theme }) => theme.colors.gray8};
+    ${({ theme }) => theme.fonts.title_semibold_20};
+  `,
+
+  ImgInfoDetail: styled.p`
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+
+    & > span {
+      padding-top: 0.2rem;
+
+      color: ${({ theme }) => theme.colors.gray3};
+      ${({ theme }) => theme.fonts.body_medium_14};
+    }
+  `,
+
+  ImgAttachContainer: styled.article`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    gap: 2rem;
+  `,
+
+  ImgAttachArea: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 33.5rem;
+    height: 24.6rem;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+
+    & > p {
+      color: ${({ theme }) => theme.colors.gray2};
+      ${({ theme }) => theme.fonts.body_medium_14};
+    }
+  `,
+
+  ImgAttachBtn: styled.button`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 33.5rem;
+    height: 5rem;
+
+    background-color: ${({ theme }) => theme.colors.white};
+
+    border: 0.1rem solid ${({ theme }) => theme.colors.gray1};
+    border-radius: 0.5rem;
+
+    & > svg {
+      padding-right: 0.6rem;
+    }
+
+    & > span {
+      color: ${({ theme }) => theme.colors.gray3};
+      ${({ theme }) => theme.fonts.body_medium_16};
+    }
+  `,
+};

--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -16,13 +16,16 @@ const CustomImg = () => {
         </St.ImgInfoDetail>
       </St.ImgInfoContainer>
       <St.ImgAttachContainer>
+        <input id='img-input' type='file' accept='image/png' />
         <St.ImgAttachArea>
           <p>도안 이미지를 첨부해주세요</p>
         </St.ImgAttachArea>
-        <St.ImgAttachBtn type='button'>
-          <IcPhoto />
-          <span>사진 첨부하기</span>
-        </St.ImgAttachBtn>
+        <label htmlFor='img-input'>
+          <St.ImgAttachBtn>
+            <IcPhoto />
+            <span>사진 첨부하기</span>
+          </St.ImgAttachBtn>
+        </label>
       </St.ImgAttachContainer>
     </St.CustomImgWrapper>
   );
@@ -71,6 +74,10 @@ const St = {
     align-items: center;
 
     gap: 2rem;
+
+    & > input {
+      display: none;
+    }
   `,
 
   ImgAttachArea: styled.div`
@@ -89,7 +96,7 @@ const St = {
     }
   `,
 
-  ImgAttachBtn: styled.button`
+  ImgAttachBtn: styled.div`
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -1,0 +1,5 @@
+const CustomImg = () => {
+  return <div>이미지 추가추가</div>;
+};
+
+export default CustomImg;

--- a/src/pages/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/pages/Custom/NoDesign/CustomImgPage.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import CustomImg from '../../../components/Custom/NoDesgin/CustomImg';
 
 const CustomImgPage = () => {
-  return <div>이미지</div>;
+  return (
+    <>
+      <CustomImg />
+    </>
+  );
 };
 
 export default CustomImgPage;

--- a/src/pages/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/pages/Custom/NoDesign/CustomImgPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CustomImgPage = () => {
+  return <div>이미지</div>;
+};
+
+export default CustomImgPage;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #17

## 💜 작업 내용
- [x] 그려둔 이미지 도안 첨부 UI 구현
- [x] input + label 연결로 버튼 눌렀을 때 image(png) 업로드 할 수 있도록

## ✅ PR Point
### input  (type = file / accept = image/png) 으로 파일을 받고, button에 label을 걸어서 버튼 트리거로 첨부 파일을 업로드 할 수 있도록 함
```ts

...

<St.ImgAttachContainer>
        <input id='img-input' type='file' accept='image/png' />
        <St.ImgAttachArea>
          <p>도안 이미지를 첨부해주세요</p>
        </St.ImgAttachArea>
        <label htmlFor='img-input'>
          <St.ImgAttachBtn>
            <IcPhoto />
            <span>사진 첨부하기</span>
          </St.ImgAttachBtn>
        </label>
      </St.ImgAttachContainer>

...


```

## 😡 Trouble Shooting
- button에 flex를 줘도 되는가 ? => 됨
- button 안에 div 되는가? => 안됨 BUT span은 됨
근데? 알고 보니까 label 처리 해줘야 대서 걍 div로 함 ㅋ

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/4f9cd1be-8169-4f22-9ae1-c19adbe4b0ee
