### PR TITLE
[CustomImgPage] 이미 그려둔 도안 이미지 미리보기 및 삭제 구현

### DIFF
--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -1,32 +1,13 @@
 import { styled } from 'styled-components';
-import { IcCheckSmallGray, IcPhoto } from '../../../assets/icon';
+
+import CustomImgHeader from './CustomImgHeader';
+import CustomImgAttach from './CustomImgAttach';
 
 const CustomImg = () => {
   return (
     <St.CustomImgWrapper>
-      <St.ImgInfoContainer>
-        <St.ImgInfoTitle>그려둔 도안 이미지를 첨부해주세요</St.ImgInfoTitle>
-        <St.ImgInfoDetail>
-          <IcCheckSmallGray />
-          <span>선택 크기보다 0cm 이상 여유 있는 크기로 첨부해주세요</span>
-        </St.ImgInfoDetail>
-        <St.ImgInfoDetail>
-          <IcCheckSmallGray />
-          <span>투명한 배경, 고화질 png 파일로 1장 첨부해주세요</span>
-        </St.ImgInfoDetail>
-      </St.ImgInfoContainer>
-      <St.ImgAttachContainer>
-        <input id='img-input' type='file' accept='image/png' />
-        <St.ImgAttachArea>
-          <p>도안 이미지를 첨부해주세요</p>
-        </St.ImgAttachArea>
-        <label htmlFor='img-input'>
-          <St.ImgAttachBtn>
-            <IcPhoto />
-            <span>사진 첨부하기</span>
-          </St.ImgAttachBtn>
-        </label>
-      </St.ImgAttachContainer>
+      <CustomImgHeader />
+      <CustomImgAttach />
     </St.CustomImgWrapper>
   );
 };
@@ -38,84 +19,5 @@ const St = {
     display: flex;
     flex-direction: column;
     align-items: center;
-  `,
-
-  ImgInfoContainer: styled.article`
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-
-    margin: 5.6rem 0 3.6rem;
-  `,
-
-  ImgInfoTitle: styled.h2`
-    margin-bottom: 0.9rem;
-
-    color: ${({ theme }) => theme.colors.gray8};
-    ${({ theme }) => theme.fonts.title_semibold_20};
-  `,
-
-  ImgInfoDetail: styled.p`
-    display: flex;
-    align-items: center;
-    gap: 0.2rem;
-
-    & > span {
-      padding-top: 0.2rem;
-
-      color: ${({ theme }) => theme.colors.gray3};
-      ${({ theme }) => theme.fonts.body_medium_14};
-    }
-  `,
-
-  ImgAttachContainer: styled.article`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    gap: 2rem;
-
-    & > input {
-      display: none;
-    }
-  `,
-
-  ImgAttachArea: styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    width: 33.5rem;
-    height: 24.6rem;
-
-    background-color: ${({ theme }) => theme.colors.bg};
-
-    & > p {
-      color: ${({ theme }) => theme.colors.gray2};
-      ${({ theme }) => theme.fonts.body_medium_14};
-    }
-  `,
-
-  ImgAttachBtn: styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    width: 33.5rem;
-    height: 5rem;
-
-    background-color: ${({ theme }) => theme.colors.white};
-
-    border: 0.1rem solid ${({ theme }) => theme.colors.gray1};
-    border-radius: 0.5rem;
-
-    & > svg {
-      padding-right: 0.6rem;
-    }
-
-    & > span {
-      color: ${({ theme }) => theme.colors.gray3};
-      ${({ theme }) => theme.fonts.body_medium_16};
-    }
   `,
 };

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -2,21 +2,16 @@ import { styled } from 'styled-components';
 import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useState } from 'react';
 
-// interface customImgState {
-//   previewURL: string;
-//   fileBlob: null;
-// }
-
 const CustomImgAttach = () => {
   const [previewURL, setPreivewURL] = useState('');
 
   const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // console.log('!!!', thumbnailURL);
     const { files } = e.target;
-    if (!files || !files[0]) return;
+    if (!files || !files[0]) return; // early return
 
-    const fileBlob = files[0];
+    const fileBlob = files[0]; // 서버 통신 시 보낼 타입
 
+    // FileReader로 이미지 미리보기 구현
     const reader = new FileReader();
     reader.readAsDataURL(fileBlob);
     reader.onloadend = () => {

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -1,12 +1,14 @@
 import { styled } from 'styled-components';
-import { IcPhoto } from '../../../assets/icon';
+import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useState } from 'react';
 
 const CustomImgAttach = () => {
   const [thumbnailURL, setThumbnailURL] = useState<string>('');
 
   const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // console.log('!!!', thumbnailURL);
     const { files } = e.target;
+    console.log(files);
     if (!files || !files[0]) return;
 
     const fileBlob = files[0];
@@ -20,13 +22,22 @@ const CustomImgAttach = () => {
     };
   };
 
+  const handleClickImgPreviewDelBtn = () => {
+    setThumbnailURL('');
+  };
+
   return (
     <St.ImgAttachContainer>
       <input id='img-input' type='file' accept='image/png' onChange={handleChangeImgAttach} />
       {thumbnailURL ? (
-        <St.ImgPreviewArea>
-          <img src={thumbnailURL} alt='그려둔 도안 이미지 미리보기' />
-        </St.ImgPreviewArea>
+        <St.ImgPreviewConatiner>
+          <St.ImgPreviewDelBtn type='button' onClick={handleClickImgPreviewDelBtn}>
+            <IcCancelDark />
+          </St.ImgPreviewDelBtn>
+          <St.ImgPreviewArea>
+            <img src={thumbnailURL} alt='그려둔 도안 이미지 미리보기' />
+          </St.ImgPreviewArea>
+        </St.ImgPreviewConatiner>
       ) : (
         <St.ImgAttachArea>
           <p>도안 이미지를 첨부해주세요</p>
@@ -71,6 +82,25 @@ const St = {
       color: ${({ theme }) => theme.colors.gray2};
       ${({ theme }) => theme.fonts.body_medium_14};
     }
+  `,
+
+  ImgPreviewConatiner: styled.div`
+    position: relative;
+  `,
+
+  ImgPreviewDelBtn: styled.button`
+    position: absolute;
+    right: 0;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0.2rem;
+
+    background-color: ${({ theme }) => theme.colors.gray7};
   `,
 
   ImgPreviewArea: styled.div`

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -1,13 +1,37 @@
 import { styled } from 'styled-components';
 import { IcPhoto } from '../../../assets/icon';
+import React, { useState } from 'react';
 
 const CustomImgAttach = () => {
+  const [thumbnailURL, setThumbnailURL] = useState<string>('');
+
+  const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
+    if (!files || !files[0]) return;
+
+    const fileBlob = files[0];
+
+    const reader = new FileReader();
+    reader.readAsDataURL(fileBlob);
+    reader.onloadend = () => {
+      const base64ImgURL = reader.result as string;
+      setThumbnailURL(base64ImgURL);
+      // console.log('fileReader 방식: \n', base64data);
+    };
+  };
+
   return (
     <St.ImgAttachContainer>
-      <input id='img-input' type='file' accept='image/png' />
-      <St.ImgAttachArea>
-        <p>도안 이미지를 첨부해주세요</p>
-      </St.ImgAttachArea>
+      <input id='img-input' type='file' accept='image/png' onChange={handleChangeImgAttach} />
+      {thumbnailURL ? (
+        <St.ImgPreviewArea>
+          <img src={thumbnailURL} alt='그려둔 도안 이미지 미리보기' />
+        </St.ImgPreviewArea>
+      ) : (
+        <St.ImgAttachArea>
+          <p>도안 이미지를 첨부해주세요</p>
+        </St.ImgAttachArea>
+      )}
       <label htmlFor='img-input'>
         <St.ImgAttachBtn>
           <IcPhoto />
@@ -46,6 +70,20 @@ const St = {
     & > p {
       color: ${({ theme }) => theme.colors.gray2};
       ${({ theme }) => theme.fonts.body_medium_14};
+    }
+  `,
+
+  ImgPreviewArea: styled.div`
+    width: 33.5rem;
+    height: 24.6rem;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+
+    & > img {
+      width: 100%;
+      height: 100%;
+
+      object-fit: contain;
     }
   `,
 

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -1,0 +1,74 @@
+import { styled } from 'styled-components';
+import { IcPhoto } from '../../../assets/icon';
+
+const CustomImgAttach = () => {
+  return (
+    <St.ImgAttachContainer>
+      <input id='img-input' type='file' accept='image/png' />
+      <St.ImgAttachArea>
+        <p>도안 이미지를 첨부해주세요</p>
+      </St.ImgAttachArea>
+      <label htmlFor='img-input'>
+        <St.ImgAttachBtn>
+          <IcPhoto />
+          <span>사진 첨부하기</span>
+        </St.ImgAttachBtn>
+      </label>
+    </St.ImgAttachContainer>
+  );
+};
+
+export default CustomImgAttach;
+
+const St = {
+  ImgAttachContainer: styled.article`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    gap: 2rem;
+
+    & > input {
+      display: none;
+    }
+  `,
+
+  ImgAttachArea: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 33.5rem;
+    height: 24.6rem;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+
+    & > p {
+      color: ${({ theme }) => theme.colors.gray2};
+      ${({ theme }) => theme.fonts.body_medium_14};
+    }
+  `,
+
+  ImgAttachBtn: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 33.5rem;
+    height: 5rem;
+
+    background-color: ${({ theme }) => theme.colors.white};
+
+    border: 0.1rem solid ${({ theme }) => theme.colors.gray1};
+    border-radius: 0.5rem;
+
+    & > svg {
+      padding-right: 0.6rem;
+    }
+
+    & > span {
+      color: ${({ theme }) => theme.colors.gray3};
+      ${({ theme }) => theme.fonts.body_medium_16};
+    }
+  `,
+};

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -2,13 +2,17 @@ import { styled } from 'styled-components';
 import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useState } from 'react';
 
+// interface customImgState {
+//   previewURL: string;
+//   fileBlob: null;
+// }
+
 const CustomImgAttach = () => {
-  const [thumbnailURL, setThumbnailURL] = useState<string>('');
+  const [previewURL, setPreivewURL] = useState('');
 
   const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
     // console.log('!!!', thumbnailURL);
     const { files } = e.target;
-    console.log(files);
     if (!files || !files[0]) return;
 
     const fileBlob = files[0];
@@ -16,26 +20,25 @@ const CustomImgAttach = () => {
     const reader = new FileReader();
     reader.readAsDataURL(fileBlob);
     reader.onloadend = () => {
-      const base64ImgURL = reader.result as string;
-      setThumbnailURL(base64ImgURL);
-      // console.log('fileReader 방식: \n', base64data);
+      setPreivewURL(reader.result as string);
+      e.target.value = ''; // 같은 파일을 올리면 change 이벤트 인지 못해서 여기서 초기화
     };
   };
 
   const handleClickImgPreviewDelBtn = () => {
-    setThumbnailURL('');
+    setPreivewURL('');
   };
 
   return (
     <St.ImgAttachContainer>
       <input id='img-input' type='file' accept='image/png' onChange={handleChangeImgAttach} />
-      {thumbnailURL ? (
+      {previewURL ? (
         <St.ImgPreviewConatiner>
           <St.ImgPreviewDelBtn type='button' onClick={handleClickImgPreviewDelBtn}>
             <IcCancelDark />
           </St.ImgPreviewDelBtn>
           <St.ImgPreviewArea>
-            <img src={thumbnailURL} alt='그려둔 도안 이미지 미리보기' />
+            <img src={previewURL} alt='그려둔 도안 이미지 미리보기' />
           </St.ImgPreviewArea>
         </St.ImgPreviewConatiner>
       ) : (

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -3,7 +3,7 @@ import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useState } from 'react';
 
 const CustomImgAttach = () => {
-  const [previewURL, setPreivewURL] = useState('');
+  const [previewURL, setPreviewURL] = useState('');
 
   const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
@@ -15,27 +15,27 @@ const CustomImgAttach = () => {
     const reader = new FileReader();
     reader.readAsDataURL(fileBlob);
     reader.onloadend = () => {
-      setPreivewURL(reader.result as string);
+      setPreviewURL(reader.result as string);
       e.target.value = ''; // 같은 파일을 올리면 change 이벤트 인지 못해서 여기서 초기화
     };
   };
 
   const handleClickImgPreviewDelBtn = () => {
-    setPreivewURL('');
+    setPreviewURL('');
   };
 
   return (
     <St.ImgAttachContainer>
       <input id='imgInput' type='file' accept='image/png' onChange={handleChangeImgAttach} />
       {previewURL ? (
-        <St.ImgPreviewConatiner>
+        <St.ImgPreviewContainer>
           <St.ImgPreviewDelBtn type='button' onClick={handleClickImgPreviewDelBtn}>
             <IcCancelDark />
           </St.ImgPreviewDelBtn>
           <St.ImgPreviewArea>
-            <img src={previewURL} alt='그려둔 도안 이미지 미리보기' />
+            <img src={previewURL} alt='그려둔-도안-이미지-미리보기' />
           </St.ImgPreviewArea>
-        </St.ImgPreviewConatiner>
+        </St.ImgPreviewContainer>
       ) : (
         <St.ImgAttachArea>
           <p>도안 이미지를 첨부해주세요</p>
@@ -82,7 +82,7 @@ const St = {
     }
   `,
 
-  ImgPreviewConatiner: styled.div`
+  ImgPreviewContainer: styled.div`
     position: relative;
   `,
 

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -26,7 +26,7 @@ const CustomImgAttach = () => {
 
   return (
     <St.ImgAttachContainer>
-      <input id='img-input' type='file' accept='image/png' onChange={handleChangeImgAttach} />
+      <input id='imgInput' type='file' accept='image/png' onChange={handleChangeImgAttach} />
       {previewURL ? (
         <St.ImgPreviewConatiner>
           <St.ImgPreviewDelBtn type='button' onClick={handleClickImgPreviewDelBtn}>
@@ -41,7 +41,7 @@ const CustomImgAttach = () => {
           <p>도안 이미지를 첨부해주세요</p>
         </St.ImgAttachArea>
       )}
-      <label htmlFor='img-input'>
+      <label htmlFor='imgInput'>
         <St.ImgAttachBtn>
           <IcPhoto />
           <span>사진 첨부하기</span>

--- a/src/components/Custom/NoDesgin/CustomImgHeader.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgHeader.tsx
@@ -1,0 +1,50 @@
+import { styled } from 'styled-components';
+import { IcCheckSmallGray } from '../../../assets/icon';
+
+const CustomImgHeader = () => {
+  return (
+    <St.ImgInfoContainer>
+      <St.ImgInfoTitle>그려둔 도안 이미지를 첨부해주세요</St.ImgInfoTitle>
+      <St.ImgInfoDetail>
+        <IcCheckSmallGray />
+        <span>선택 크기보다 0cm 이상 여유 있는 크기로 첨부해주세요</span>
+      </St.ImgInfoDetail>
+      <St.ImgInfoDetail>
+        <IcCheckSmallGray />
+        <span>투명한 배경, 고화질 png 파일로 1장 첨부해주세요</span>
+      </St.ImgInfoDetail>
+    </St.ImgInfoContainer>
+  );
+};
+
+export default CustomImgHeader;
+
+const St = {
+  ImgInfoContainer: styled.article`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    margin: 5.6rem 0 3.6rem;
+  `,
+
+  ImgInfoTitle: styled.h2`
+    margin-bottom: 0.9rem;
+
+    color: ${({ theme }) => theme.colors.gray8};
+    ${({ theme }) => theme.fonts.title_semibold_20};
+  `,
+
+  ImgInfoDetail: styled.p`
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+
+    & > span {
+      padding-top: 0.2rem;
+
+      color: ${({ theme }) => theme.colors.gray3};
+      ${({ theme }) => theme.fonts.body_medium_14};
+    }
+  `,
+};


### PR DESCRIPTION
## 🔥 Related Issues
resolved #43 

## 💜 작업 내용
- [x] 이미지 업로드 기능
- [x] 이미지 미리보기 기능
- [x] 이미지 삭제 기능 
<br/>

## ✅ PR Point
### 이미지 미리보기 기능
```ts
{previewURL ? (
        <St.ImgPreviewConatiner>
          <St.ImgPreviewDelBtn type='button' onClick={handleClickImgPreviewDelBtn}>
            <IcCancelDark />
          </St.ImgPreviewDelBtn>
          <St.ImgPreviewArea>
            <img src={previewURL} alt='그려둔 도안 이미지 미리보기' />
          </St.ImgPreviewArea>
        </St.ImgPreviewConatiner>
      ) : (
        <St.ImgAttachArea>
          <p>도안 이미지를 첨부해주세요</p>
        </St.ImgAttachArea>
      )}
```
* fileReader로 업로드 한 이미지의 base64 string type URL을 생성함
* previewURL이 있을 시 보여줌

### 미리보기 이미지 삭제
```ts
  const handleClickImgPreviewDelBtn = () => {
    setPreivewURL('');
  };
```
* 삭제 버튼 누르면 previewURL을 빈 스트링으로 만들어 줘서 미리보기 삭제 구현


<br/>

## 😡 Trouble Shooting
- 동일 이미지를 다시 첨부 했을 때 첨부가 안되는 오류 발생 -> e.target.value = ""로 초기화 시켜 해결함

<br/>

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/344417a7-1dc5-4570-8125-79124da8cd24

=> png 파일만 선택 가능

## 📚 Reference
- [동일 파일 업로드 불가능 해결](https://velog.io/@raverana96/react-input-file%EC%97%90-%EA%B0%99%EC%9D%80-%ED%8C%8C%EC%9D%BC-%EB%8B%A4%EC%8B%9C-%EC%98%AC%EB%A6%AC%EA%B8%B0-image-preview)