### PR TITLE
[LoginPage] 인증번호 제한시간 만료 시 뜨는 뷰 구현

### DIFF
--- a/src/components/Register/ErrorMessage.tsx
+++ b/src/components/Register/ErrorMessage.tsx
@@ -7,7 +7,7 @@ interface ErrorMessageProps {
 const ErrorMessage = ({ isTimeout }: ErrorMessageProps) => {
   return (
     <St.NotificationWrapper>
-      <St.Notification>{isTimeout ? '재인증 버튼을 눌러 다시 인증해주세요.' : '인증번호가 잘못되었어요'}.</St.Notification>
+      <St.Notification>{isTimeout ? '재인증 버튼을 눌러 다시 인증해주세요.' : '인증번호가 잘못되었어요.'}</St.Notification>
     </St.NotificationWrapper>
   );
 };

--- a/src/components/Register/ErrorMessage.tsx
+++ b/src/components/Register/ErrorMessage.tsx
@@ -1,9 +1,13 @@
 import { styled } from 'styled-components';
 
-const ErrorMessage = () => {
+interface ErrorMessageProps {
+  isTimeout: boolean;
+}
+
+const ErrorMessage = ({ isTimeout }: ErrorMessageProps) => {
   return (
     <St.NotificationWrapper>
-      <St.Notification>인증번호가 잘못되었어요.</St.Notification>
+      <St.Notification>{isTimeout ? '재인증 버튼을 눌러 다시 인증해주세요.' : '인증번호가 잘못되었어요'}.</St.Notification>
     </St.NotificationWrapper>
   );
 };

--- a/src/components/Register/InputCertificationForm.tsx
+++ b/src/components/Register/InputCertificationForm.tsx
@@ -14,6 +14,8 @@ const InputCertificationForm = () => {
 
   const isError = !isCorrect && certificationLen === 4;
 
+  const [isTimeout, setIsTimeout] = useState(false);
+
   const handleChangeCertificationInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (parseInt(e.target.value) === CERTIFICATION_NUM) {
       setIsCorrect(true);
@@ -34,14 +36,15 @@ const InputCertificationForm = () => {
   return (
     <St.CertificationInputWrapper>
       <St.CertificationInput
-        id={isError ? 'errorInput' : 'successInput'}
+        id={isError || isTimeout ? 'errorInput' : 'successInput'}
+        disabled={isTimeout ? true : false}
         onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 4)}
         placeholder='인증번호를 입력해주세요'
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeCertificationInput(e)}
       ></St.CertificationInput>
-      <Timer isCorrect={isCorrect} />
+      <Timer isCorrect={isCorrect} isTimeout={isTimeout} setIsTimeout={setIsTimeout} />
 
-      {isError && <ErrorMessage />}
+      {(isError || isTimeout) && <ErrorMessage isTimeout={isTimeout} />}
     </St.CertificationInputWrapper>
   );
 };

--- a/src/components/Register/InputCertificationForm.tsx
+++ b/src/components/Register/InputCertificationForm.tsx
@@ -74,6 +74,10 @@ const St = {
       ${({ theme }) => theme.fonts.body_medium_16};
     }
 
+    &:focus {
+      outline: 0;
+    }
+
     &#errorInput {
       border: 0.1rem solid ${({ theme }) => theme.colors.red};
     }

--- a/src/components/Register/InputCertificationForm.tsx
+++ b/src/components/Register/InputCertificationForm.tsx
@@ -38,7 +38,7 @@ const InputCertificationForm = () => {
       <St.CertificationInput
         id={isError || isTimeout ? 'errorInput' : 'successInput'}
         disabled={isTimeout ? true : false}
-        onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 4)}
+        onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 4, 'onlyNum')}
         placeholder='인증번호를 입력해주세요'
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeCertificationInput(e)}
       ></St.CertificationInput>

--- a/src/components/Register/RegisterName.tsx
+++ b/src/components/Register/RegisterName.tsx
@@ -57,6 +57,10 @@ const St = {
     &::placeholder {
       color: ${({ theme }) => theme.colors.gray2};
     }
+
+    &:focus {
+      outline: 0;
+    }
   `,
 };
 

--- a/src/components/Register/RegisterName.tsx
+++ b/src/components/Register/RegisterName.tsx
@@ -20,7 +20,7 @@ const RegisterName = () => {
         <St.InputContent
           placeholder='실명을 입력해주세요'
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeInputContent(e)}
-          onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 5)}
+          onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 5, 'onlyString')}
         ></St.InputContent>
       </St.InputContentsWrapper>
 

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -49,7 +49,7 @@ const RegisterPhoneNumForm = ({ isVisible, setIsVisible }: RegisterPhoneNumFormP
       <St.InputContent
         placeholder='전화번호를 입력해주세요'
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeInputContent(e)}
-        onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 13)}
+        onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 13, 'phoneNum')}
       ></St.InputContent>
       <St.SendMessageBtn
         type='button'
@@ -101,10 +101,8 @@ const St = {
 
     color: ${({ theme }) => theme.colors.white};
 
-    background-color: ${({ ischanged, isvisible, theme, $length }) =>
-      (ischanged && isvisible) || length === 13
-        ? theme.colors.gray7
-        : theme.colors.gray3};
+    background-color: ${({ $ischanged, $isvisible, theme, $length }) =>
+      ($ischanged && $isvisible) || $length === 13 ? theme.colors.gray7 : theme.colors.gray3};
 
     ${({ theme }) => theme.fonts.title_semibold_16};
   `,

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -90,6 +90,10 @@ const St = {
       color: ${({ theme }) => theme.colors.gray2};
       ${({ theme }) => theme.fonts.body_medium_16};
     }
+
+    &:focus {
+      outline: 0;
+    }
   `,
 
   SendMessageBtn: styled.button<{ $ischanged: boolean; $isvisible: boolean; $length: number }>`

--- a/src/components/Register/Timer.tsx
+++ b/src/components/Register/Timer.tsx
@@ -4,9 +4,11 @@ import { styled } from 'styled-components';
 
 interface TimerProps {
   isCorrect: boolean;
+  isTimeout: boolean;
+  setIsTimeout: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Timer = memo(({ isCorrect }: TimerProps) => {
+const Timer = memo(({ isCorrect, isTimeout, setIsTimeout }: TimerProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
   const INTERVAL = 1000;
   const [leftTime, setLeftTime] = useState<number>(MINUTES_IN_MS);
@@ -25,7 +27,7 @@ const Timer = memo(({ isCorrect }: TimerProps) => {
     if (leftTime <= 0) {
       // timer 반복 중단
       clearInterval(timer);
-      alert('제한 시간이 끝났습니다.');
+      setIsTimeout(true);
     }
 
     if (isCorrect) {
@@ -35,22 +37,22 @@ const Timer = memo(({ isCorrect }: TimerProps) => {
     return () => {
       clearInterval(timer);
     };
-  }, [leftTime, isCorrect]);
+  }, [leftTime, isCorrect, setIsTimeout]);
 
   return (
-    <St.AuthTimer>
-      {minutes} : {second}
+    <St.AuthTimer $isTimeout={isTimeout}>
+      {isTimeout ? '시간 만료' : `${minutes} : ${second}`}
     </St.AuthTimer>
   );
 });
 
 const St = {
-  AuthTimer: styled.span`
+  AuthTimer: styled.span<{ $isTimeout: boolean }>`
     padding-top: 1.2rem;
     position: absolute;
     right: 4rem;
 
-    color: ${({ theme }) => theme.colors.gray7};
+    color: ${({ theme, $isTimeout }) => ($isTimeout ? theme.colors.red : theme.colors.gray7)};
 
     ${({ theme }) => theme.fonts.body_medium_16};
   `,

--- a/src/utils/sliceMaxLength.ts
+++ b/src/utils/sliceMaxLength.ts
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const sliceMaxLength = (
-  e: React.ChangeEvent<HTMLInputElement>,
+  e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
   maxLength: number,
-  inputType: string,
+  inputType?: string,
 ) => {
   switch (inputType) {
     case 'onlyNum':
@@ -16,6 +16,7 @@ const sliceMaxLength = (
 
     case 'onlyString':
       e.target.value = e.target.value.replace(/[^ㄱ-힣a-zA-Z]/g, '');
+      break;
   }
 
   if (e.target.value.length > maxLength) {

--- a/src/utils/sliceMaxLength.ts
+++ b/src/utils/sliceMaxLength.ts
@@ -1,6 +1,23 @@
 import React from 'react';
 
-const sliceMaxLength = (e: React.ChangeEvent<HTMLInputElement>, maxLength: number) => {
+const sliceMaxLength = (
+  e: React.ChangeEvent<HTMLInputElement>,
+  maxLength: number,
+  inputType: string,
+) => {
+  switch (inputType) {
+    case 'onlyNum':
+      e.target.value = e.target.value.replace(/[^0-9]/g, '');
+      break;
+
+    case 'phoneNum':
+      e.target.value = e.target.value.replace(/[^0123456789-]/g, '');
+      break;
+
+    case 'onlyString':
+      e.target.value = e.target.value.replace(/[^ㄱ-힣a-zA-Z]/g, '');
+  }
+
   if (e.target.value.length > maxLength) {
     e.target.value = e.target.value.slice(0, maxLength);
   }


### PR DESCRIPTION
## 🔥 Related Issues
resolved #127 

## 💜 작업 내용
- [x] 인증번호 제한 시간 만료 시 뜨는 뷰 구현
- [x] input 입력 타입 제한

## ✅ PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
    - 인증번호 제한 시간 만료 시 뜨는 뷰를 구현했습니다.
    - `isTimeout` 상태를 만들어서 해당 상태가 true일 경우에만 스타일이 적용되도록 했습니다.
    - 시간이 만료되면 인증번호 작성 폼이 비활성화 처리되도록 구현했습니다.
    
    <br />
    
    ```
    <Timer isCorrect={isCorrect} isTimeout={isTimeout} setIsTimeout={setIsTimeout} />
    
    <St.AuthTimer $isTimeout={isTimeout}>
      {isTimeout ? '시간 만료' : `${minutes} : ${second}`}
    </St.AuthTimer>
    ```
    
    ```
    {(isError || isTimeout) && <ErrorMessage isTimeout={isTimeout} />}
    
    <St.NotificationWrapper>
      <St.Notification>{isTimeout ? '재인증 버튼을 눌러 다시 인증해주세요.' : '인증번호가 잘못되었어요.'}</St.Notification>
    </St.NotificationWrapper>
    ```
    
    <br />
    
    - sliceMaxLength()의 인자로 inputType을 받아와서 입력받을 수 있는 타입을 제한했습니다.
    - 타입 제한에 `정규식`과 `switch-case`를 활용했습니다.
    
    <br />
    
   ```
   switch (inputType) {
    case 'onlyNum':
      e.target.value = e.target.value.replace(/[^0-9]/g, '');
      break;

    case 'phoneNum':
      e.target.value = e.target.value.replace(/[^0123456789-]/g, '');
      break;

    case 'onlyString':
      e.target.value = e.target.value.replace(/[^ㄱ-힣a-zA-Z]/g, '');
  }
   ```    

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="552" alt="스크린샷 2023-07-11 오후 10 21 02" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/1dd28c73-02d3-43ab-bfa6-a0e9b2ddc752">

