### PR TITLE
Order page/#41 wrap page layout

### DIFF
--- a/src/components/Order/OrderFooter.tsx
+++ b/src/components/Order/OrderFooter.tsx
@@ -37,8 +37,6 @@ const St = {
         height: 100%;
 
         color: ${({ theme }) => theme.colors.pink5};
-        font: ${({ theme }) => theme.fonts.title_semibold_18};
+        ${({ theme }) => theme.fonts.title_semibold_18};
     `,
-    };
-
-    export default MainFooter;
+};

--- a/src/components/Order/OrderFooter.tsx
+++ b/src/components/Order/OrderFooter.tsx
@@ -1,0 +1,44 @@
+import styled from "styled-components"
+import { useNavigate } from 'react-router-dom';
+
+const OrderFooter = () => {
+    const TOTAL_PRICE = 5500;
+
+    const navigate = useNavigate();
+
+    const handleClickButton = () => {
+        //추후 ReceiptPage로 이동해야 함 
+    };
+
+    return (
+        <St.footer>
+            <St.button type='button' onClick={handleClickButton}>
+                {TOTAL_PRICE.toLocaleString()}원 결제하기
+            </St.button>
+        </St.footer>
+    )
+}
+
+export default OrderFooter;
+
+const St = {
+    footer: styled.footer`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 7rem;
+
+        background-color: ${({ theme }) => theme.colors.gray9};
+    `,
+
+    button: styled.button`
+        width: 100%;
+        height: 100%;
+
+        color: ${({ theme }) => theme.colors.pink5};
+        font: ${({ theme }) => theme.fonts.title_semibold_18};
+    `,
+    };
+
+    export default MainFooter;

--- a/src/pages/Login/OrderPage.tsx
+++ b/src/pages/Login/OrderPage.tsx
@@ -5,6 +5,7 @@ import PaymentInfo from "../../components/Order/PaymentInfo";
 import RefundInfo from "../../components/Order/RefundInfo";
 import PageLayout from "../../components/PageLayout";
 import Header from "../../components/Header";
+import OrderFooter from "../../components/Order/OrderFooter";
 
 const OrderPage = () => {
 
@@ -12,7 +13,7 @@ const OrderPage = () => {
     return <Header leftSection={<div>left</div>} title='주문하기' rightSection={<div>left</div>} />;
   }
   return (
-    <PageLayout renderHeader={renderOrderPageHeader}>
+    <PageLayout renderHeader={renderOrderPageHeader} footer={<OrderFooter/>}>
         <ProductInfo/>
         <St.Line/>
         <DeliveryInfo/>

--- a/src/pages/Login/OrderPage.tsx
+++ b/src/pages/Login/OrderPage.tsx
@@ -3,10 +3,16 @@ import ProductInfo from "../../components/Order/ProductInfo";
 import DeliveryInfo from "../../components/Order/DeliveryInfo";
 import PaymentInfo from "../../components/Order/PaymentInfo";
 import RefundInfo from "../../components/Order/RefundInfo";
+import PageLayout from "../../components/PageLayout";
+import Header from "../../components/Header";
 
 const OrderPage = () => {
+
+  const renderOrderPageHeader = () => {
+    return <Header leftSection={<div>left</div>} title='주문하기' rightSection={<div>left</div>} />;
+  }
   return (
-    <div>
+    <PageLayout renderHeader={renderOrderPageHeader}>
         <ProductInfo/>
         <St.Line/>
         <DeliveryInfo/>
@@ -14,7 +20,7 @@ const OrderPage = () => {
         <PaymentInfo/>
         <St.Line/>
         <RefundInfo/>
-    </div>
+    </PageLayout>
   )
 }
 

--- a/src/pages/Login/OrderPage.tsx
+++ b/src/pages/Login/OrderPage.tsx
@@ -6,11 +6,12 @@ import RefundInfo from "../../components/Order/RefundInfo";
 import PageLayout from "../../components/PageLayout";
 import Header from "../../components/Header";
 import OrderFooter from "../../components/Order/OrderFooter";
+import { IcBackDark, IcCancelDark } from "../../assets/icon";
 
 const OrderPage = () => {
 
   const renderOrderPageHeader = () => {
-    return <Header leftSection={<div>left</div>} title='주문하기' rightSection={<div>left</div>} />;
+    return <Header leftSection={<div><IcBackDark/></div>} title='주문하기' rightSection={<div><IcCancelDark/></div>} />;
   }
   return (
     <PageLayout renderHeader={renderOrderPageHeader} footer={<OrderFooter/>}>


### PR DESCRIPTION
## 🔥 Related Issues
resolved #41 

## 💜 작업 내용
- [x] OrderPage 컴포넌트 만들어둔거에 PageLayout (Header, Footer) 붙여줌 

## ✅ PR Point
- 단순 퍼블리싱
- Header -> 아이콘과 제목만 설정해줌
- Footer -> OrderFooter 컴포넌트 구현함 (navigate 제외) 

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/3e01bded-eac2-4e04-b191-188b6ce79334



