### PR TITLE
[Common] header 공통 컴포넌트 구현 (뒤로 가기, 취소하기)

### DIFF
--- a/src/common/Modal/EscapeModal/EscapeModal.tsx
+++ b/src/common/Modal/EscapeModal/EscapeModal.tsx
@@ -1,0 +1,25 @@
+import ModalPortal from '../ModalPortal';
+import EscapeModalForm from './EscapeModalForm';
+
+interface EscapeModalProps {
+  setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const EscapeModal = ({ setModalOn }: EscapeModalProps) => {
+  return (
+    <ModalPortal>
+      <EscapeModalForm
+        onClose={() => setModalOn(false)}
+        pageName={'LoginPage'}
+        title={'정말 그만두시나요?'}
+        subTitle={
+          '프로필 설정만 마치면, 회원가입 과정이 모두 끝납니다. 중간에 나가시면 정보가 사라져요.'
+        }
+        continueBtn={'설정 계속하기'}
+        stopBtn={'그만하기'}
+      />
+    </ModalPortal>
+  );
+};
+
+export default EscapeModal;

--- a/src/common/Modal/EscapeModal/EscapeModalForm.tsx
+++ b/src/common/Modal/EscapeModal/EscapeModalForm.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import { IcCancelDark } from '../../assets/icon';
+import { IcCancelDark } from '../../../assets/icon';
 import { useNavigate } from 'react-router-dom';
 
-interface ModalProps {
+interface EscapeModalFormProps {
   onClose: () => void;
   pageName: string;
   title: string;
@@ -11,7 +11,7 @@ interface ModalProps {
   stopBtn: string;
 }
 
-const Modal = ({ onClose, pageName, title, subTitle, continueBtn, stopBtn }: ModalProps) => {
+const EscapeModalForm = ({ onClose, pageName, title, subTitle, continueBtn, stopBtn }: EscapeModalFormProps) => {
   const navigate = useNavigate();
 
   const handleClickStopBtn = () => {
@@ -150,4 +150,4 @@ const St = {
   `,
 };
 
-export default Modal;
+export default EscapeModalForm;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,20 +1,20 @@
 import { styled } from 'styled-components';
 
 interface HeaderProps {
-  backBtn: React.ReactNode;
+  leftSection: React.ReactNode;
   title?: string;
-  cancelBtn: React.ReactNode;
+  rightSection: React.ReactNode;
   transparent?: boolean;
   progressBar?: React.ReactNode;
 }
 
-const Header = ({ backBtn, title, cancelBtn, transparent, progressBar }: HeaderProps) => {
+const Header = ({ leftSection, title, rightSection, transparent, progressBar }: HeaderProps) => {
   return (
     <div>
       <St.header transparent={transparent}>
-        {backBtn}
+        {leftSection}
         {title && <St.title>{title}</St.title>}
-        {cancelBtn}
+        {rightSection}
       </St.header>
 
       {progressBar}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,23 +1,24 @@
 import { styled } from 'styled-components';
 
 interface HeaderProps {
-  leftSection: React.ReactNode;
+  backBtn: React.ReactNode;
   title?: string;
-  rightSection: React.ReactNode;
+  cancelBtn: React.ReactNode;
   transparent?: boolean;
+  progressBar?: React.ReactNode;
 }
 
-const Header = ({ leftSection, title, rightSection, transparent }: HeaderProps) => {
+const Header = ({ backBtn, title, cancelBtn, transparent, progressBar }: HeaderProps) => {
   return (
-    <>
+    <div>
       <St.header transparent={transparent}>
-        {leftSection}
+        {backBtn}
         {title && <St.title>{title}</St.title>}
-        {rightSection}
+        {cancelBtn}
       </St.header>
-      {/* 여기에 프로그레스바 추가 (아래처럼 쓰면 됨)*/}
-      {/* <ProgressBar curStep={2} maxStep={5} /> */}
-    </>
+
+      {progressBar}
+    </div>
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 interface HeaderProps {
   leftSection: React.ReactNode;
   title?: string;
-  rightSection: React.ReactNode;
+  rightSection?: React.ReactNode;
   transparent?: boolean;
   progressBar?: React.ReactNode;
 }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,29 +2,36 @@ import { useState } from 'react';
 import MainFooter from '../components/MainFooter';
 import Header from '../components/Header';
 import PageLayout from '../components/PageLayout';
-import ProgressBar from '../common/ProgressBar';
-import BackBtn from '../utils/BackBtn';
-import CancelBtn from '../utils/CancelBtn';
-import EscapeModal from '../common/Modal/EscapeModal/EscapeModal'
+// import ProgressBar from '../common/ProgressBar';
+// import BackBtn from '../utils/BackBtn';
+// import CancelBtn from '../utils/CancelBtn';
+// import EscapeModal from '../common/Modal/EscapeModal/EscapeModal'
 
 const MainPage = () => {
-  const [modalOn, setModalOn] = useState(false);
+  // 모달 사용할 때  활용
+  // const [modalOn, setModalOn] = useState(false);
 
   const reanderMainPageHeader = () => {
     return (
       <Header
         transparent={true}
-        backBtn={<BackBtn />}
+        leftSection={<div>left</div>}
         title='Test'
-        cancelBtn={
-          <CancelBtn
-            modalOn={modalOn}
-            setModalOn={setModalOn}
-            targetModal={<EscapeModal setModalOn={setModalOn} />}
-          />
-        }
+        rightSection={<div>right</div>}
+
+        // 이런 식으로 헤더 공통 컴포넌트 활용
+        // leftSection={<BackBtn />}
+        // rightSection={
+        //   <CancelBtn
+        //     modalOn={modalOn}
+        //     setModalOn={setModalOn}
+        //     targetModal={<EscapeModal setModalOn={setModalOn} />}
+        //   />
+        // }
+
+        // 이런 식으로 프로그레스 바 활용
         // 전체 페이지수, 현재 페이지 단계 알아서 넣기
-        progressBar={<ProgressBar curStep={1} maxStep={3} />}
+        // progressBar={<ProgressBar curStep={1} maxStep={3} />}
       />
     );
   };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -20,7 +20,7 @@ const MainPage = () => {
           <CancelBtn
             modalOn={modalOn}
             setModalOn={setModalOn}
-            children={<EscapeModal setModalOn={setModalOn} />}
+            targetModal={<EscapeModal setModalOn={setModalOn} />}
           />
         }
         // 전체 페이지수, 현재 페이지 단계 알아서 넣기

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,15 +1,30 @@
+import { useState } from 'react';
 import MainFooter from '../components/MainFooter';
 import Header from '../components/Header';
 import PageLayout from '../components/PageLayout';
+import ProgressBar from '../common/ProgressBar';
+import BackBtn from '../utils/BackBtn';
+import CancelBtn from '../utils/CancelBtn';
+import EscapeModal from '../common/Modal/EscapeModal/EscapeModal'
 
 const MainPage = () => {
+  const [modalOn, setModalOn] = useState(false);
+
   const reanderMainPageHeader = () => {
     return (
       <Header
         transparent={true}
-        leftSection={<div>left</div>}
+        backBtn={<BackBtn />}
         title='Test'
-        rightSection={<div>right</div>}
+        cancelBtn={
+          <CancelBtn
+            modalOn={modalOn}
+            setModalOn={setModalOn}
+            children={<EscapeModal setModalOn={setModalOn} />}
+          />
+        }
+        // 전체 페이지수, 현재 페이지 단계 알아서 넣기
+        progressBar={<ProgressBar curStep={1} maxStep={3} />}
       />
     );
   };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+// import { useState } from 'react';
 import MainFooter from '../components/MainFooter';
 import Header from '../components/Header';
 import PageLayout from '../components/PageLayout';

--- a/src/utils/BackBtn.tsx
+++ b/src/utils/BackBtn.tsx
@@ -1,0 +1,14 @@
+import { IcBackDark } from '../assets/icon';
+import { useNavigate } from 'react-router-dom';
+
+const BackBtn = () => {
+  const navigate = useNavigate();
+
+  const handleClickBack = () => {
+    navigate(-1);
+  };
+
+  return <IcBackDark onClick={handleClickBack} />;
+};
+
+export default BackBtn;

--- a/src/utils/CancelBtn.tsx
+++ b/src/utils/CancelBtn.tsx
@@ -3,18 +3,17 @@ import { IcCancelDark } from '../assets/icon';
 interface CancelBtnProps {
   modalOn: boolean;
   setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
-  tagetModal: React.ReactNode;
+  targetModal: React.ReactNode;
 }
 
-const CancelBtn = ({ modalOn, setModalOn, tagetModal }: CancelBtnProps) => {
+const CancelBtn = ({ modalOn, setModalOn, targetModal }: CancelBtnProps) => {
   const handleClickCancelBtn = () => {
     setModalOn(true);
   };
 
   return (
     <div>
-      <IcCancelDark onClick={handleClickCancelBtn} />;
-      {modalOn && tagetModal}
+      <IcCancelDark onClick={handleClickCancelBtn} />;{modalOn && targetModal}
     </div>
   );
 };

--- a/src/utils/CancelBtn.tsx
+++ b/src/utils/CancelBtn.tsx
@@ -1,0 +1,21 @@
+import { IcCancelDark } from '../assets/icon';
+
+interface CancelBtnProps {
+  modalOn: boolean;
+  setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
+  children: React.ReactNode;
+}
+
+const CancelBtn = ({ modalOn, setModalOn, children }: CancelBtnProps) => {
+  const handleClickCancelBtn = () => {
+    setModalOn(true);
+  };
+
+  return (
+    <div>
+      <IcCancelDark onClick={handleClickCancelBtn} />;{modalOn && children}
+    </div>
+  );
+};
+
+export default CancelBtn;

--- a/src/utils/CancelBtn.tsx
+++ b/src/utils/CancelBtn.tsx
@@ -3,17 +3,18 @@ import { IcCancelDark } from '../assets/icon';
 interface CancelBtnProps {
   modalOn: boolean;
   setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
-  children: React.ReactNode;
+  tagetModal: React.ReactNode;
 }
 
-const CancelBtn = ({ modalOn, setModalOn, children }: CancelBtnProps) => {
+const CancelBtn = ({ modalOn, setModalOn, tagetModal }: CancelBtnProps) => {
   const handleClickCancelBtn = () => {
     setModalOn(true);
   };
 
   return (
     <div>
-      <IcCancelDark onClick={handleClickCancelBtn} />;{modalOn && children}
+      <IcCancelDark onClick={handleClickCancelBtn} />;
+      {modalOn && tagetModal}
     </div>
   );
 };

--- a/src/utils/CancelBtn.tsx
+++ b/src/utils/CancelBtn.tsx
@@ -13,7 +13,8 @@ const CancelBtn = ({ modalOn, setModalOn, targetModal }: CancelBtnProps) => {
 
   return (
     <div>
-      <IcCancelDark onClick={handleClickCancelBtn} />;{modalOn && targetModal}
+      <IcCancelDark onClick={handleClickCancelBtn} />
+      {modalOn && targetModal}
     </div>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #106 

## 💜 작업 내용
- [x] header 공통 컴포넌트 구현
- [x] 뒤로가기 컴포넌트 
- [x] 취소하기 컴포넌트 

## ✅ PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
    - `뒤로가기` 컴포넌트
    
    <br />
    
    ```
    const handleClickBack = () => {
    navigate(-1);
  };
    ```
    
    - `취소하기` 컴포넌트
    - targetModel을 props로 넘겨주었습니다.
    - `EscapeModal.tsx`에서 모달에 필요한 내용을 채워주면 됩니다.
    
     <br />
    
    ```
    // MainPage.tsx
  <CancelBtn
            modalOn={modalOn}
            setModalOn={setModalOn}
            targetModal={<EscapeModal setModalOn={setModalOn} />}
          />
    ```
    
