### PR TITLE
[OrderPage] 포인트 부족 뷰 조건부 렌더링

### DIFF
--- a/src/components/Order/PaymentInfo.tsx
+++ b/src/components/Order/PaymentInfo.tsx
@@ -8,6 +8,7 @@ const PaymentInfo = () => {
     const DELIVERY_PRICE = 3000;
     const MY_POINT = 10000;
     const LEFT_POINT = 4500;
+    const LACK_POINT = 4500;
 
     return (
         <div>
@@ -40,13 +41,21 @@ const PaymentInfo = () => {
                         <span>P</span>
                     </St.MainText>
                 </St.PointText>
-                <St.PointText>
+                {/* <St.PointText>
                     <St.MainText>남는 포인트</St.MainText>
                     <St.MainText>
                         <span>{LEFT_POINT.toLocaleString()}</span>
                         <span>P</span>
                     </St.MainText>
+                </St.PointText> */}
+                <St.PointText>
+                    <St.MainText>부족한 포인트</St.MainText>
+                    <St.MainText>
+                        <St.LackText>{LACK_POINT.toLocaleString()}</St.LackText>
+                        <span>P</span>
+                    </St.MainText>
                 </St.PointText>
+                <St.ChargeBtn>충전하기</St.ChargeBtn>
             </St.PointContainer>
         </div>
     )
@@ -90,6 +99,9 @@ const St = {
             ${({ theme }) => theme.fonts.body_medium_16};
         }
     `,
+    LackText: styled.span`
+        color: ${({ theme }) => theme.colors.red};
+    `,
     MainPrice: styled.span`
         margin: 0rem 0.4rem 0.5rem 0rem;
         ${({ theme }) => theme.fonts.title_extrabold_24};
@@ -120,5 +132,16 @@ const St = {
         align-items: center;
 
         width: 100%;    
+    `,
+    ChargeBtn: styled.button`
+        padding: 1.2rem 1.8rem;
+        width: 9.1rem;
+        height: 4.5rem;
+        margin-left: 24.2rem;
+
+        background-color: ${({ theme }) => theme.colors.gray7};
+        border-radius: 0.6rem;
+        ${({ theme }) => theme.fonts.title_semibold_16};
+        color: ${({ theme }) => theme.colors.white};
     `
 }

--- a/src/components/Order/PaymentInfo.tsx
+++ b/src/components/Order/PaymentInfo.tsx
@@ -8,7 +8,7 @@ const PaymentInfo = () => {
     const DELIVERY_PRICE = 3000;
     const MY_POINT = 10000;
     const RESULT_POINT = 4500;  // 서버에서 주는 '남는/부족한 포인트 값'
-    const IS_LACK = false;  // 서버에서 주는 '포인트 부족 여부'
+    // const IS_LACK = false;  // 서버에서 주는 '포인트 부족 여부'
 
     return (
         <div>
@@ -42,15 +42,17 @@ const PaymentInfo = () => {
                     </St.MainText>
                 </St.PointText>
                 <St.PointText>
-                    <St.MainText>{IS_LACK? '부족한 포인트' : '남는 포인트'}</St.MainText>
+                    {/* <St.MainText>{IS_LACK? '부족한 포인트' : '남는 포인트'}</St.MainText> */}
+                    <St.MainText>남는 포인트</St.MainText>
                     <St.MainText>
-                        {IS_LACK? 
+                        {/* {IS_LACK? 
                         <St.LackText>{RESULT_POINT.toLocaleString()}</St.LackText> :
-                        <span>{RESULT_POINT.toLocaleString()}</span>}
+                        <span>{RESULT_POINT.toLocaleString()}</span>} */}
+                        <span>{RESULT_POINT.toLocaleString()}</span>
                         <span>P</span>
                     </St.MainText>
                 </St.PointText>
-                {IS_LACK? <St.ChargeBtn>충전하기</St.ChargeBtn> : ``}
+                {/* {IS_LACK? <St.ChargeBtn>충전하기</St.ChargeBtn> : ``} */}
             </St.PointContainer>
         </div>
     )
@@ -94,9 +96,9 @@ const St = {
             ${({ theme }) => theme.fonts.body_medium_16};
         }
     `,
-    LackText: styled.span`
+    /* LackText: styled.span`
         color: ${({ theme }) => theme.colors.red};
-    `,
+    `, */
     MainPrice: styled.span`
         margin: 0rem 0.4rem 0.5rem 0rem;
         ${({ theme }) => theme.fonts.title_extrabold_24};

--- a/src/components/Order/PaymentInfo.tsx
+++ b/src/components/Order/PaymentInfo.tsx
@@ -7,8 +7,8 @@ const PaymentInfo = () => {
     const ITEM_PRICE = 2500;
     const DELIVERY_PRICE = 3000;
     const MY_POINT = 10000;
-    const LEFT_POINT = 4500;
-    const LACK_POINT = 4500;
+    const RESULT_POINT = 4500;  // 서버에서 주는 '남는/부족한 포인트 값'
+    const IS_LACK = false;  // 서버에서 주는 '포인트 부족 여부'
 
     return (
         <div>
@@ -41,21 +41,16 @@ const PaymentInfo = () => {
                         <span>P</span>
                     </St.MainText>
                 </St.PointText>
-                {/* <St.PointText>
-                    <St.MainText>남는 포인트</St.MainText>
-                    <St.MainText>
-                        <span>{LEFT_POINT.toLocaleString()}</span>
-                        <span>P</span>
-                    </St.MainText>
-                </St.PointText> */}
                 <St.PointText>
-                    <St.MainText>부족한 포인트</St.MainText>
+                    <St.MainText>{IS_LACK? '부족한 포인트' : '남는 포인트'}</St.MainText>
                     <St.MainText>
-                        <St.LackText>{LACK_POINT.toLocaleString()}</St.LackText>
+                        {IS_LACK? 
+                        <St.LackText>{RESULT_POINT.toLocaleString()}</St.LackText> :
+                        <span>{RESULT_POINT.toLocaleString()}</span>}
                         <span>P</span>
                     </St.MainText>
                 </St.PointText>
-                <St.ChargeBtn>충전하기</St.ChargeBtn>
+                {IS_LACK? <St.ChargeBtn>충전하기</St.ChargeBtn> : ``}
             </St.PointContainer>
         </div>
     )


### PR DESCRIPTION
## 🔥 Related Issues
resolved #117 

## 💜 작업 내용
- [x] 포인트 부족 뷰 별도 구현
- [x] `isLack` flag에 따라 조건부 렌더링 

## ✅ PR Point
- 서버 측에서 남는 포인트/부족한 포인트 구분 없이 result_price, is_lack 를 준다고 함 
- 따라서 저도 is_lack의 여부에 따라 조건부 렌더링 되도록 구현했습니다. 

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/01029a3e-8446-434f-a04c-154494489ff0



## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)