### PR TITLE
[TransferPage] 계좌 송금 페이지 UI 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,6 +3,7 @@ import MainPage from './pages/MainPage';
 import LoginPage from './pages/Login/LoginPage';
 import RegisterPage from './pages/Register/RegisterPage';
 import RegisterPhoneNum from './components/Register/RegisterPhoneNum';
+import TransferPage from './pages/pointCharge/TransferPage';
 
 const Router = () => {
   return (
@@ -12,6 +13,7 @@ const Router = () => {
         <Route path='/login' element={<LoginPage />} />
         <Route path='/register' element={<RegisterPage />} />
         <Route path='/input-number' element={<RegisterPhoneNum />} />
+        <Route path='/point-transfer' element={<TransferPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/PointCharge/AccountCopy.tsx
+++ b/src/components/PointCharge/AccountCopy.tsx
@@ -1,10 +1,12 @@
 import { styled } from 'styled-components';
 
 const AccountCopy = () => {
+  const ACCOUNT_INFO = '우리은행 1002259752313 (손*진)';
+
   return (
     <St.TransferAccountContainer>
       <St.AccountBox>
-        <St.AccountBoxNum>신한 110 498 876418 (손애진)</St.AccountBoxNum>
+        <St.AccountBoxNum>{ACCOUNT_INFO}</St.AccountBoxNum>
         <St.AccountBoxCopy>복사하기</St.AccountBoxCopy>
       </St.AccountBox>
     </St.TransferAccountContainer>

--- a/src/components/PointCharge/AccountCopy.tsx
+++ b/src/components/PointCharge/AccountCopy.tsx
@@ -1,0 +1,43 @@
+import { styled } from 'styled-components';
+
+const AccountCopy = () => {
+  return (
+    <St.TransferAccountContainer>
+      <St.AccountBox>
+        <St.AccountBoxNum>신한 110 498 876418 (손애진)</St.AccountBoxNum>
+        <St.AccountBoxCopy>복사하기</St.AccountBoxCopy>
+      </St.AccountBox>
+    </St.TransferAccountContainer>
+  );
+};
+
+export default AccountCopy;
+
+const St = {
+  TransferAccountContainer: styled.article``,
+
+  AccountBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1.6rem;
+
+    width: 33.5rem;
+    height: 12.2rem;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+
+    border-radius: 0.6rem;
+  `,
+
+  AccountBoxNum: styled.p`
+    color: ${({ theme }) => theme.colors.gray7};
+    ${({ theme }) => theme.fonts.title_semibold_16};
+  `,
+
+  AccountBoxCopy: styled.p`
+    color: ${({ theme }) => theme.colors.gray2};
+    ${({ theme }) => theme.fonts.body_underline_medium_14};
+  `,
+};

--- a/src/components/PointCharge/Transfer.tsx
+++ b/src/components/PointCharge/Transfer.tsx
@@ -1,5 +1,0 @@
-const Transfer = () => {
-  return <div>전송전송</div>;
-};
-
-export default Transfer;

--- a/src/components/PointCharge/Transfer.tsx
+++ b/src/components/PointCharge/Transfer.tsx
@@ -1,0 +1,5 @@
+const Transfer = () => {
+  return <div>전송전송</div>;
+};
+
+export default Transfer;

--- a/src/components/PointCharge/TransferMain.tsx
+++ b/src/components/PointCharge/TransferMain.tsx
@@ -1,0 +1,5 @@
+const TransferMain = () => {
+  return <div>전송전송</div>;
+};
+
+export default TransferMain;

--- a/src/components/PointCharge/TransferMain.tsx
+++ b/src/components/PointCharge/TransferMain.tsx
@@ -1,5 +1,134 @@
+import { styled } from 'styled-components';
+
 const TransferMain = () => {
-  return <div>전송전송</div>;
+  return (
+    <>
+      <St.TransferWrapper>
+        <St.TransferInfoContainer>
+          <St.InfoMsgHeader>
+            <St.InfoMsgTitle>아래 계좌로 금액을 송금해주세요</St.InfoMsgTitle>
+            <St.InfoMsgDetail>
+              아래 계좌로 해당 금액을 입금하면 포인트가 충전 됩니다.
+            </St.InfoMsgDetail>
+          </St.InfoMsgHeader>
+          <St.InfoPriceMain>
+            <St.InfoPriceLeft>총 충전 금액</St.InfoPriceLeft>
+            <St.InfoPriceRight>
+              <St.RightPrice>3000</St.RightPrice>
+              <St.RightUnit>원</St.RightUnit>
+            </St.InfoPriceRight>
+          </St.InfoPriceMain>
+        </St.TransferInfoContainer>
+        <St.TransferAccountContainer>
+          <St.AccountBox>
+            <St.AccountBoxNum>신한 110 498 876418 (손애진)</St.AccountBoxNum>
+            <St.AccountBoxCopy>복사하기</St.AccountBoxCopy>
+          </St.AccountBox>
+        </St.TransferAccountContainer>
+      </St.TransferWrapper>
+      <St.TransferSectionDivide />
+    </>
+  );
 };
 
 export default TransferMain;
+
+const St = {
+  TransferWrapper: styled.section`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    margin: 5.6rem 1.8rem 0 2.2rem;
+  `,
+
+  TransferInfoContainer: styled.article`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  InfoMsgHeader: styled.header`
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+  `,
+
+  InfoMsgTitle: styled.h2`
+    color: ${({ theme }) => theme.colors.gray8};
+    ${({ theme }) => theme.fonts.title_semibold_20};
+  `,
+
+  InfoMsgDetail: styled.p`
+    color: ${({ theme }) => theme.colors.gray3};
+    ${({ theme }) => theme.fonts.body_medium_14};
+  `,
+
+  InfoPriceMain: styled.main`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    padding: 1.7rem 0 2.2rem 0;
+    margin: 1.7rem 0 1.5rem 0;
+  `,
+
+  InfoPriceLeft: styled.p`
+    width: fit-content;
+
+    color: ${({ theme }) => theme.colors.gray4};
+    ${({ theme }) => theme.fonts.body_medium_16};
+  `,
+
+  InfoPriceRight: styled.p`
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  `,
+
+  RightPrice: styled.span`
+    color: ${({ theme }) => theme.colors.pink5};
+    ${({ theme }) => theme.fonts.title_semibold_24};
+  `,
+
+  RightUnit: styled.span`
+    color: ${({ theme }) => theme.colors.gray4};
+    ${({ theme }) => theme.fonts.body_medium_16};
+  `,
+
+  TransferAccountContainer: styled.article``,
+
+  AccountBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1.6rem;
+
+    width: 33.5rem;
+    height: 12.2rem;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+
+    border-radius: 0.6rem;
+  `,
+
+  AccountBoxNum: styled.p`
+    color: ${({ theme }) => theme.colors.gray7};
+    ${({ theme }) => theme.fonts.title_semibold_16};
+  `,
+
+  AccountBoxCopy: styled.p`
+    color: ${({ theme }) => theme.colors.gray2};
+    ${({ theme }) => theme.fonts.body_underline_medium_14};
+  `,
+
+  TransferSectionDivide: styled.hr`
+    width: 100%;
+    height: 1.3rem;
+    margin-top: 18.8rem;
+
+    border: none;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+  `,
+};

--- a/src/components/PointCharge/TransferMain.tsx
+++ b/src/components/PointCharge/TransferMain.tsx
@@ -4,7 +4,7 @@ import AccountCopy from './AccountCopy';
 const TransferMain = () => {
   return (
     <>
-      <St.TransferWrapper>
+      <St.TransferMainWrapper>
         <St.TransferInfoContainer>
           <St.InfoMsgHeader>
             <St.InfoMsgTitle>아래 계좌로 금액을 송금해주세요</St.InfoMsgTitle>
@@ -21,7 +21,7 @@ const TransferMain = () => {
           </St.InfoPriceMain>
         </St.TransferInfoContainer>
         <AccountCopy />
-      </St.TransferWrapper>
+      </St.TransferMainWrapper>
 
       <St.TransferSectionDivide />
     </>
@@ -31,7 +31,7 @@ const TransferMain = () => {
 export default TransferMain;
 
 const St = {
-  TransferWrapper: styled.section`
+  TransferMainWrapper: styled.section`
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/PointCharge/TransferMain.tsx
+++ b/src/components/PointCharge/TransferMain.tsx
@@ -2,6 +2,8 @@ import { styled } from 'styled-components';
 import AccountCopy from './AccountCopy';
 
 const TransferMain = () => {
+  const chargedCost = 3000;
+
   return (
     <>
       <St.TransferMainWrapper>
@@ -9,13 +11,13 @@ const TransferMain = () => {
           <St.InfoMsgHeader>
             <St.InfoMsgTitle>아래 계좌로 금액을 송금해주세요</St.InfoMsgTitle>
             <St.InfoMsgDetail>
-              아래 계좌로 해당 금액을 입금하면 포인트가 충전 됩니다.
+              정확하게 송금하지 않을 시 추후에 주문이 취소될 수 있어요
             </St.InfoMsgDetail>
           </St.InfoMsgHeader>
           <St.InfoPriceMain>
-            <St.InfoPriceLeft>총 충전 금액</St.InfoPriceLeft>
+            <St.InfoPriceLeft>충전 금액</St.InfoPriceLeft>
             <St.InfoPriceRight>
-              <St.RightPrice>3000</St.RightPrice>
+              <St.RightPrice>{chargedCost.toLocaleString()}</St.RightPrice>
               <St.RightUnit>원</St.RightUnit>
             </St.InfoPriceRight>
           </St.InfoPriceMain>

--- a/src/components/PointCharge/TransferMain.tsx
+++ b/src/components/PointCharge/TransferMain.tsx
@@ -1,4 +1,5 @@
 import { styled } from 'styled-components';
+import AccountCopy from './AccountCopy';
 
 const TransferMain = () => {
   return (
@@ -19,13 +20,9 @@ const TransferMain = () => {
             </St.InfoPriceRight>
           </St.InfoPriceMain>
         </St.TransferInfoContainer>
-        <St.TransferAccountContainer>
-          <St.AccountBox>
-            <St.AccountBoxNum>신한 110 498 876418 (손애진)</St.AccountBoxNum>
-            <St.AccountBoxCopy>복사하기</St.AccountBoxCopy>
-          </St.AccountBox>
-        </St.TransferAccountContainer>
+        <AccountCopy />
       </St.TransferWrapper>
+
       <St.TransferSectionDivide />
     </>
   );
@@ -93,33 +90,6 @@ const St = {
   RightUnit: styled.span`
     color: ${({ theme }) => theme.colors.gray4};
     ${({ theme }) => theme.fonts.body_medium_16};
-  `,
-
-  TransferAccountContainer: styled.article``,
-
-  AccountBox: styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 1.6rem;
-
-    width: 33.5rem;
-    height: 12.2rem;
-
-    background-color: ${({ theme }) => theme.colors.bg};
-
-    border-radius: 0.6rem;
-  `,
-
-  AccountBoxNum: styled.p`
-    color: ${({ theme }) => theme.colors.gray7};
-    ${({ theme }) => theme.fonts.title_semibold_16};
-  `,
-
-  AccountBoxCopy: styled.p`
-    color: ${({ theme }) => theme.colors.gray2};
-    ${({ theme }) => theme.fonts.body_underline_medium_14};
   `,
 
   TransferSectionDivide: styled.hr`

--- a/src/components/PointCharge/TransferPolicy.tsx
+++ b/src/components/PointCharge/TransferPolicy.tsx
@@ -1,7 +1,63 @@
-import React from 'react';
+import { styled } from 'styled-components';
+
+import ic_check from '../../assets/icon/ic_check.svg';
+import ic_check_selected from '../../assets/icon/ic_check_selected.svg';
+import { IcArrowRightDark } from '../../assets/icon';
 
 const TransferPolicy = () => {
-  return <div>예비포인트 정책</div>;
+  return (
+    <St.TransferPolicyWrapper>
+      <St.PolicyAgreeCheckBox type='checkbox' id='pointAgree' />
+      <label htmlFor='pointAgree'></label>
+
+      <St.PolicyAgreeTouchArea>
+        <St.PolicyAgreeText>예비포인트 정책 관련 설명에 동의합니다</St.PolicyAgreeText>
+        <IcArrowRightDark />
+      </St.PolicyAgreeTouchArea>
+    </St.TransferPolicyWrapper>
+  );
 };
 
 export default TransferPolicy;
+
+const St = {
+  TransferPolicyWrapper: styled.section`
+    display: flex;
+    align-items: center;
+    gap: 1.1rem;
+
+    padding: 3.1rem 4.9rem 4rem 2rem;
+  `,
+
+  PolicyAgreeCheckBox: styled.input`
+    display: none;
+
+    & + label {
+      display: block;
+
+      width: 2.4rem;
+      height: 2.4rem;
+
+      background: url(${ic_check});
+    }
+
+    &:checked + label {
+      display: block;
+
+      width: 2.4rem;
+      height: 2.4rem;
+
+      background: url(${ic_check_selected});
+    }
+  `,
+
+  PolicyAgreeTouchArea: styled.article`
+    display: flex;
+    gap: 0.3rem;
+  `,
+
+  PolicyAgreeText: styled.p`
+    color: ${({ theme }) => theme.colors.gray4};
+    ${({ theme }) => theme.fonts.body_medium_16};
+  `,
+};

--- a/src/components/PointCharge/TransferPolicy.tsx
+++ b/src/components/PointCharge/TransferPolicy.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TransferPolicy = () => {
+  return <div>예비포인트 정책</div>;
+};
+
+export default TransferPolicy;

--- a/src/pages/pointCharge/TransferPage.tsx
+++ b/src/pages/pointCharge/TransferPage.tsx
@@ -1,9 +1,11 @@
-import Transfer from '../../components/PointCharge/Transfer';
+import TransferMain from '../../components/PointCharge/TransferMain';
+import TransferPolicy from '../../components/PointCharge/TransferPolicy';
 
 const TransferPage = () => {
   return (
     <>
-      <Transfer />
+      <TransferMain />
+      <TransferPolicy />
     </>
   );
 };

--- a/src/pages/pointCharge/TransferPage.tsx
+++ b/src/pages/pointCharge/TransferPage.tsx
@@ -1,5 +1,11 @@
+import Transfer from '../../components/PointCharge/Transfer';
+
 const TransferPage = () => {
-  return <>계좌번호 전송</>;
+  return (
+    <>
+      <Transfer />
+    </>
+  );
 };
 
 export default TransferPage;

--- a/src/pages/pointCharge/TransferPage.tsx
+++ b/src/pages/pointCharge/TransferPage.tsx
@@ -1,0 +1,5 @@
+const TransferPage = () => {
+  return <>계좌번호 전송</>;
+};
+
+export default TransferPage;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #49

## 💜 작업 내용
- [x] 계좌 전송 정보 영역 UI 구현
- [x] 예비포인트 정책 동의 영역 UI 구현

## ✅ PR Point
- 단순 퍼블리싱입니다 간단히 구조만 봐주세요
- 예비포인트 정책 동의는 리소스 아끼기 위해 숭이가 구현한 부분을 참고했습니다
- 계좌 번호 복사 부분은 복사하기 기능이 붙어 컴포넌트로 따로 빼줬습니다

## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화 

<img width="340" alt="image" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/e2b711f4-e53d-4eb9-ac1a-522d957fa43d">
