### PR TITLE
My tattoo/#12 mytattoo page UI

### DIFF
--- a/src/common/BigScrollContainer.tsx
+++ b/src/common/BigScrollContainer.tsx
@@ -1,0 +1,66 @@
+import ScrollContainer from 'react-indiana-drag-scroll';
+import { styled } from 'styled-components';
+
+const BigScrollContainer = ({ title, children }: { title: string; children: React.ReactNode }) => {
+  return (
+    <>
+      <St.BigScrollWrapper>
+        <St.BigScrollHeader>
+          <St.BigScrollTitle>{title}</St.BigScrollTitle>
+        </St.BigScrollHeader>
+        <St.BigScrollItemWrapper>
+          <ScrollContainer vertical={false} className='scroll-container'>
+            {children}
+          </ScrollContainer>
+        </St.BigScrollItemWrapper>
+      </St.BigScrollWrapper>
+      <St.Divide />
+    </>
+  );
+};
+
+const St = {
+  BigScrollWrapper: styled.section`
+    margin-top: 2.2rem;
+    padding-left: 2rem;
+
+    background-color: ${({ theme }) => theme.colors.white};
+  `,
+
+  BigScrollHeader: styled.header`
+    display: flex;
+  `,
+
+  BigScrollTitle: styled.h2`
+    // title eng bold 18 필요
+    font-size: 1.8rem;
+    font-weight: bold;
+  `,
+
+  BigScrollItemWrapper: styled.div`
+    display: flex;
+    gap: 1.2rem;
+    justify-content: space-between;
+    margin-top: 2.2rem;
+    margin-right: 1.2rem;
+
+    .scroll-container {
+      display: flex;
+      gap: 1.2rem;
+
+      height: 23.3rem;
+      width: 100%;
+    }
+  `,
+
+  Divide: styled.hr`
+    width: 100%;
+    height: 1.3rem;
+
+    border: none;
+
+    background-color: ${({ theme }) => theme.colors.bg};
+  `,
+};
+
+export default BigScrollContainer;

--- a/src/common/SmallScrollContainer.tsx
+++ b/src/common/SmallScrollContainer.tsx
@@ -1,0 +1,54 @@
+import { styled } from 'styled-components';
+import ScrollContainer from 'react-indiana-drag-scroll';
+
+const SmallScrollContainer = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <St.SmallScrollWrapper>
+      <header>
+        <St.SmallScrollHeaderTitle>{title}</St.SmallScrollHeaderTitle>
+      </header>
+      <St.SmallScrollItemWrapper>
+        <ScrollContainer vertical={false} className='scroll-container'>
+          {children}
+        </ScrollContainer>
+      </St.SmallScrollItemWrapper>
+    </St.SmallScrollWrapper>
+  );
+};
+
+const St = {
+  SmallScrollWrapper: styled.section`
+    padding-left: 2rem;
+    margin-top: 2.8rem;
+  `,
+
+  SmallScrollHeaderTitle: styled.h2`
+    // title eng bold 18 필요
+    font-size: 1.8rem;
+    font-weight: bold;
+  `,
+
+  SmallScrollItemWrapper: styled.div`
+    margin-top: 2.2rem;
+    display: flex;
+    gap: 1.2rem;
+    justify-content: space-between;
+    margin-right: 1.2rem;
+
+    .scroll-container {
+      display: flex;
+      gap: 1.2rem;
+
+      height: 28rem;
+      width: 100%;
+    }
+  `,
+};
+
+export default SmallScrollContainer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 interface HeaderProps {
   leftSection: React.ReactNode;
   title?: string;
-  rightSection: React.ReactNode;
+  rightSection?: React.ReactNode;
   transparent?: boolean;
 }
 
@@ -12,7 +12,7 @@ const Header = ({ leftSection, title, rightSection, transparent }: HeaderProps) 
     <St.header transparent={transparent}>
       {leftSection}
       {title && <St.title>{title}</St.title>}
-      {rightSection}
+      {rightSection ? rightSection : <St.BlankSection />}
     </St.header>
   );
 };
@@ -32,6 +32,11 @@ const St = {
 
   title: styled.h1`
     font: ${({ theme }) => theme.fonts.title_semibold_18};
+  `,
+
+  BlankSection: styled.div`
+    width: 2.4rem;
+    height: 2.4rem;
   `,
 };
 

--- a/src/components/MyTattoo/MyCustom.tsx
+++ b/src/components/MyTattoo/MyCustom.tsx
@@ -1,141 +1,29 @@
-import ScrollContainer from 'react-indiana-drag-scroll';
-import { styled } from 'styled-components';
-import { LabelCustomSmall } from '../../assets/icon';
-
-const renderDummyImageComponent = () => {
-  return (
-    <div
-      style={{
-        width: '15.3rem',
-        height: '16.3rem',
-        backgroundColor: 'gray',
-      }}
-    ></div>
-  );
-};
+import BigScrollContainer from '../../common/BigScrollContainer';
+import MyCustomItem from './MyCustomItem';
 
 const dummyMyCustomData = [
   {
     id: 1,
     title: '타투 제목',
-    isDraft: true,
   },
   {
     id: 2,
     title: '타투 제목',
-    isDraft: true,
   },
   {
     id: 3,
     title: '타투 제목',
-    isDraft: true,
   },
 ];
 
 const MyCustom = () => {
   return (
-    <>
-      <St.MyCustomWrapper>
-        <St.MyCustomHeader>
-          <St.MyCustomTitle>MY CUSTOM</St.MyCustomTitle>
-        </St.MyCustomHeader>
-        <St.MyCustomItemWrapper>
-          <ScrollContainer vertical={false} className='scroll-container'>
-            {dummyMyCustomData.map(({ id, title, isDraft }) => {
-              return (
-                <St.MyCustomItem key={id}>
-                  <LabelCustomSmall />
-                  {renderDummyImageComponent()}
-                  <St.MyCustomItemTitle>{title}</St.MyCustomItemTitle>
-                  {isDraft && (
-                    <St.MyCustomItemDraftTag>
-                      <St.MyCustomItemDraftTagText>임시저장</St.MyCustomItemDraftTagText>
-                    </St.MyCustomItemDraftTag>
-                  )}
-                </St.MyCustomItem>
-              );
-            })}
-          </ScrollContainer>
-        </St.MyCustomItemWrapper>
-      </St.MyCustomWrapper>
-      <St.Divide />
-    </>
+    <BigScrollContainer title={'MY CUSTOM'}>
+      {dummyMyCustomData.map(({ id, title }) => {
+        return <MyCustomItem key={id} title={title} />;
+      })}
+    </BigScrollContainer>
   );
-};
-
-const St = {
-  MyCustomWrapper: styled.section`
-    margin-top: 2.2rem;
-    padding-left: 2rem;
-
-    background-color: ${({ theme }) => theme.colors.white};
-  `,
-
-  MyCustomHeader: styled.header`
-    display: flex;
-  `,
-
-  MyCustomTitle: styled.h2`
-    // title eng bold 18 필요
-    font-size: 1.8rem;
-    font-weight: bold;
-  `,
-
-  MyCustomItemWrapper: styled.div`
-    display: flex;
-    gap: 1.2rem;
-    justify-content: space-between;
-    margin-top: 2.2rem;
-    margin-right: 1.2rem;
-
-    .scroll-container {
-      display: flex;
-      gap: 1.2rem;
-
-      height: 28rem;
-      width: 100%;
-    }
-  `,
-
-  MyCustomItem: styled.article`
-    position: relative;
-
-    & > svg {
-      position: absolute;
-    }
-  `,
-
-  MyCustomItemTitle: styled.h3`
-    margin-top: 1.3rem;
-    ${({ theme }) => theme.fonts.body_medium_14};
-    color: ${({ theme }) => theme.colors.gray7};
-  `,
-
-  MyCustomItemDraftTag: styled.p`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 6.4rem;
-    height: 2.6rem;
-    border-radius: 0.5rem;
-    margin-top: 0.9rem;
-
-    background-color: ${({ theme }) => theme.colors.gray0};
-  `,
-
-  MyCustomItemDraftTagText: styled.span`
-    ${({ theme }) => theme.fonts.body_medium_14};
-    color: ${({ theme }) => theme.colors.gray3};
-  `,
-
-  Divide: styled.hr`
-    width: 100%;
-    height: 1.3rem;
-
-    border: none;
-
-    background-color: ${({ theme }) => theme.colors.bg};
-  `,
 };
 
 export default MyCustom;

--- a/src/components/MyTattoo/MyCustomItem.tsx
+++ b/src/components/MyTattoo/MyCustomItem.tsx
@@ -1,0 +1,42 @@
+import { styled } from 'styled-components';
+import { LabelCustomSmall } from '../../assets/icon';
+
+const renderDummyImageComponent = () => {
+  return (
+    <div
+      style={{
+        width: '15.3rem',
+        height: '16.3rem',
+        backgroundColor: 'gray',
+      }}
+    ></div>
+  );
+};
+
+const MyCustomItem = ({ title }: { title: string }) => {
+  return (
+    <St.MyCustomItem>
+      <LabelCustomSmall />
+      {renderDummyImageComponent()}
+      <St.MyCustomItemTitle>{title}</St.MyCustomItemTitle>
+    </St.MyCustomItem>
+  );
+};
+
+const St = {
+  MyCustomItem: styled.article`
+    position: relative;
+
+    & > svg {
+      position: absolute;
+    }
+  `,
+
+  MyCustomItemTitle: styled.h3`
+    margin-top: 1.3rem;
+    ${({ theme }) => theme.fonts.body_medium_14};
+    color: ${({ theme }) => theme.colors.gray7};
+  `,
+};
+
+export default MyCustomItem;

--- a/src/components/MyTattoo/MyLike.tsx
+++ b/src/components/MyTattoo/MyLike.tsx
@@ -1,17 +1,5 @@
-import { styled } from 'styled-components';
-import ScrollContainer from 'react-indiana-drag-scroll';
-
-const renderDummyImageComponent = () => {
-  return (
-    <div
-      style={{
-        width: '12.2rem',
-        height: '13rem',
-        backgroundColor: 'gray',
-      }}
-    ></div>
-  );
-};
+import SmallScrollContainer from '../../common/SmallScrollContainer';
+import MyLikeItem from './MyLikeItem';
 
 const dummyMyLikeData = [
   {
@@ -53,88 +41,20 @@ const dummyMyLikeData = [
 
 const MyLike = () => {
   return (
-    <St.MyLikeWrapper>
-      <header>
-        <St.MyLikeTitle>LIKE</St.MyLikeTitle>
-      </header>
-      <St.MyLikeItemWrapper>
-        <ScrollContainer vertical={false} className='scroll-container'>
-          {dummyMyLikeData.map(({ id, title, price, originalPrice, discountRate }) => {
-            return (
-              <article key={id}>
-                {renderDummyImageComponent()}
-                <St.MyLikeItemTitle>{title}</St.MyLikeItemTitle>
-                <St.MyLikeItemPriceTextWrapper>
-                  <St.MyLikeItemDiscountRate>{discountRate}%</St.MyLikeItemDiscountRate>
-                  <St.MyLikeItemPriceText>{price.toLocaleString()}원</St.MyLikeItemPriceText>
-                </St.MyLikeItemPriceTextWrapper>
-                <St.MyLikeItemOriginalPriceText>
-                  {originalPrice.toLocaleString()}원
-                </St.MyLikeItemOriginalPriceText>
-              </article>
-            );
-          })}
-        </ScrollContainer>
-      </St.MyLikeItemWrapper>
-    </St.MyLikeWrapper>
+    <SmallScrollContainer title={'LIKE'}>
+      {dummyMyLikeData.map(({ id, title, price, originalPrice, discountRate }) => {
+        return (
+          <MyLikeItem
+            key={id}
+            title={title}
+            price={price}
+            originalPrice={originalPrice}
+            discountRate={discountRate}
+          />
+        );
+      })}
+    </SmallScrollContainer>
   );
-};
-
-const St = {
-  MyLikeWrapper: styled.section`
-    padding-left: 2rem;
-    margin-top: 2.8rem;
-  `,
-
-  MyLikeTitle: styled.h2`
-    // title eng bold 18 필요
-    font-size: 1.8rem;
-    font-weight: bold;
-  `,
-
-  MyLikeItemWrapper: styled.div`
-    margin-top: 2.2rem;
-    display: flex;
-    gap: 1.2rem;
-    justify-content: space-between;
-    margin-right: 1.2rem;
-
-    .scroll-container {
-      display: flex;
-      gap: 1.2rem;
-
-      height: 28rem;
-      width: 100%;
-    }
-  `,
-
-  MyLikeItemTitle: styled.h3`
-    margin-top: 1.3rem;
-    ${({ theme }) => theme.fonts.body_medium_14};
-    color: ${({ theme }) => theme.colors.gray7};
-  `,
-
-  MyLikeItemPriceTextWrapper: styled.div`
-    display: flex;
-  `,
-
-  MyLikeItemDiscountRate: styled.p`
-    ${({ theme }) => theme.fonts.title_extrabold_16};
-    color: ${({ theme }) => theme.colors.pink5};
-  `,
-
-  MyLikeItemPriceText: styled.p`
-    margin-left: 0.6rem;
-
-    ${({ theme }) => theme.fonts.title_extrabold_16};
-    color: ${({ theme }) => theme.colors.gray7};
-  `,
-
-  MyLikeItemOriginalPriceText: styled.p`
-    margin-top: 0.1rem;
-    ${({ theme }) => theme.fonts.body_line_medium_12};
-    color: ${({ theme }) => theme.colors.gray1};
-  `,
 };
 
 export default MyLike;

--- a/src/components/MyTattoo/MyLikeItem.tsx
+++ b/src/components/MyTattoo/MyLikeItem.tsx
@@ -1,0 +1,71 @@
+import { styled } from 'styled-components';
+
+const renderDummyImageComponent = () => {
+  return (
+    <div
+      style={{
+        width: '12.2rem',
+        height: '13rem',
+        backgroundColor: 'gray',
+      }}
+    ></div>
+  );
+};
+
+const MyLikeItem = ({
+  title,
+  discountRate,
+  price,
+  originalPrice,
+}: {
+  title: string;
+  discountRate: number;
+  price: number;
+  originalPrice: number;
+}) => {
+  return (
+    <article>
+      {renderDummyImageComponent()}
+      <St.MyLikeItemTitle>{title}</St.MyLikeItemTitle>
+      <St.MyLikeItemPriceTextWrapper>
+        <St.MyLikeItemDiscountRate>{discountRate}%</St.MyLikeItemDiscountRate>
+        <St.MyLikeItemPriceText>{price.toLocaleString()}원</St.MyLikeItemPriceText>
+      </St.MyLikeItemPriceTextWrapper>
+      <St.MyLikeItemOriginalPriceText>
+        {originalPrice.toLocaleString()}원
+      </St.MyLikeItemOriginalPriceText>
+    </article>
+  );
+};
+
+const St = {
+  MyLikeItemTitle: styled.h3`
+    margin-top: 1.3rem;
+    ${({ theme }) => theme.fonts.body_medium_14};
+    color: ${({ theme }) => theme.colors.gray7};
+  `,
+
+  MyLikeItemPriceTextWrapper: styled.div`
+    display: flex;
+  `,
+
+  MyLikeItemDiscountRate: styled.p`
+    ${({ theme }) => theme.fonts.title_extrabold_16};
+    color: ${({ theme }) => theme.colors.pink5};
+  `,
+
+  MyLikeItemPriceText: styled.p`
+    margin-left: 0.6rem;
+
+    ${({ theme }) => theme.fonts.title_extrabold_16};
+    color: ${({ theme }) => theme.colors.gray7};
+  `,
+
+  MyLikeItemOriginalPriceText: styled.p`
+    margin-top: 0.1rem;
+    ${({ theme }) => theme.fonts.body_line_medium_12};
+    color: ${({ theme }) => theme.colors.gray1};
+  `,
+};
+
+export default MyLikeItem;

--- a/src/components/MyTattoo/MySave.tsx
+++ b/src/components/MyTattoo/MySave.tsx
@@ -1,0 +1,29 @@
+import BigScrollContainer from '../../common/BigScrollContainer';
+import MySaveItem from './MySaveItem';
+
+const dummyMySaveData = [
+  {
+    id: 1,
+    title: '타투 제목',
+  },
+  {
+    id: 2,
+    title: '타투 제목',
+  },
+  {
+    id: 3,
+    title: '타투 제목',
+  },
+];
+
+const MySave = () => {
+  return (
+    <BigScrollContainer title={'SAVE'}>
+      {dummyMySaveData.map(({ id, title }) => {
+        return <MySaveItem key={id} title={title} />;
+      })}
+    </BigScrollContainer>
+  );
+};
+
+export default MySave;

--- a/src/components/MyTattoo/MySaveItem.tsx
+++ b/src/components/MyTattoo/MySaveItem.tsx
@@ -1,0 +1,40 @@
+import { styled } from 'styled-components';
+
+const renderDummyImageComponent = () => {
+  return (
+    <div
+      style={{
+        width: '15.3rem',
+        height: '16.3rem',
+        backgroundColor: 'gray',
+      }}
+    ></div>
+  );
+};
+
+const MySaveItem = ({ title }: { title: string }) => {
+  return (
+    <St.MySaveItem>
+      {renderDummyImageComponent()}
+      <St.MySaveItemTitle>{title}</St.MySaveItemTitle>
+    </St.MySaveItem>
+  );
+};
+
+const St = {
+  MySaveItem: styled.article`
+    position: relative;
+
+    & > svg {
+      position: absolute;
+    }
+  `,
+
+  MySaveItemTitle: styled.h3`
+    margin-top: 1.3rem;
+    ${({ theme }) => theme.fonts.body_medium_14};
+    color: ${({ theme }) => theme.colors.gray7};
+  `,
+};
+
+export default MySaveItem;

--- a/src/pages/MyTattoo.tsx
+++ b/src/pages/MyTattoo.tsx
@@ -1,23 +1,28 @@
-import { IcArrowLeftGray, IcCancelDark } from '../assets/icon';
+import { useNavigate } from 'react-router-dom';
+import { IcArrowLeftGray } from '../assets/icon';
 import Header from '../components/Header';
 import MyCustom from '../components/MyTattoo/MyCustom';
 import MyLike from '../components/MyTattoo/MyLike';
+import MySave from '../components/MyTattoo/MySave';
 import PageLayout from '../components/PageLayout';
 
 const renderMyTattooHeader = () => {
-  return (
-    <Header
-      leftSection={<IcArrowLeftGray />}
-      title='내 타투'
-      rightSection={<IcCancelDark />}
-    ></Header>
-  );
+  const LeftButton = () => {
+    const navigate = useNavigate();
+    const handleClickBack = () => {
+      navigate('/');
+    };
+    return <IcArrowLeftGray onClick={handleClickBack} />;
+  };
+
+  return <Header leftSection={<LeftButton />} title='내 타투'></Header>;
 };
 
 const MyTattoo = () => {
   return (
     <PageLayout renderHeader={renderMyTattooHeader}>
       <MyCustom />
+      <MySave />
       <MyLike />
     </PageLayout>
   );


### PR DESCRIPTION
## 🔥 Related Issues
resolved #12 

## 💜 작업 내용
- [x] Scroll Container 기능 추상화
- [x] Header 디자인 변경 사항 반영

## ✅ PR Point
```tsx
const SmallScrollContainer = ({
  title,
  children,
}: {
  title: string;
  children: React.ReactNode;
}) => {
  return (
    <St.SmallScrollWrapper>
      <header>
        <St.SmallScrollHeaderTitle>{title}</St.SmallScrollHeaderTitle>
      </header>
      <St.SmallScrollItemWrapper>
        <ScrollContainer vertical={false} className='scroll-container'>
          {children}
        </ScrollContainer>
      </St.SmallScrollItemWrapper>
    </St.SmallScrollWrapper>
  );
};
```
title로 Scroll Container의 메인 타이틀 작성.
children으로 해당 컴포넌트가 담을 아이템을 받아 구성.
BigScrollContainer는 HotCustom에 주로 사용.
SmallScrillContainer는 비슷한 제품, 찜하기에 사용.

## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지

## ☀️ 스크린샷 / GIF / 화면 녹화 
![image](https://github.com/TEAM-TATTOUR/tattour-client/assets/51692363/d385069b-9096-4e4f-8ced-c5d6c9738066)
![image](https://github.com/TEAM-TATTOUR/tattour-client/assets/51692363/2b0d5f63-129c-4453-9d6b-e36c24770a9f)

## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)