### PR TITLE
[Common] 에러, 만료 페이지 퍼블리싱

### DIFF
--- a/src/common/PreventAccess/PreventAccess.tsx
+++ b/src/common/PreventAccess/PreventAccess.tsx
@@ -4,12 +4,12 @@ import { useNavigate } from 'react-router-dom';
 
 interface PreventAccessProps {
   title: string;
-  btn_contents: string;
+  btnContents: string;
   // 에러 페이지에서 쓰일건지, 만료 페이지에서 쓰일건지 구분
   isError?: boolean;
 }
 
-const PreventAccess = ({ title, btn_contents, isError }: PreventAccessProps) => {
+const PreventAccess = ({ title, btnContents, isError }: PreventAccessProps) => {
   const navigate = useNavigate();
 
   const handleClickButton = () => {

--- a/src/common/PreventAccess/PreventAccess.tsx
+++ b/src/common/PreventAccess/PreventAccess.tsx
@@ -20,7 +20,7 @@ const PreventAccess = ({ title, btnContents, isError }: PreventAccessProps) => {
     <St.ContentsWrapper>
       <IcError />
       <St.Title>{title}</St.Title>
-      <St.Button onClick={handleClickButton}>{btn_contents}</St.Button>
+      <St.Button onClick={handleClickButton}>{btnContents}</St.Button>
     </St.ContentsWrapper>
   );
 };

--- a/src/common/PreventAccess/PreventAccess.tsx
+++ b/src/common/PreventAccess/PreventAccess.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { IcError } from '../../assets/icon';
+import { useNavigate } from 'react-router-dom';
+
+interface PreventAccessProps {
+  title: string;
+  btn_contents: string;
+  // 에러 페이지에서 쓰일건지, 만료 페이지에서 쓰일건지 구분
+  isError?: boolean;
+}
+
+const PreventAccess = ({ title, btn_contents, isError }: PreventAccessProps) => {
+  const navigate = useNavigate();
+
+  const handleClickButton = () => {
+    isError ? window.location.reload() : navigate('/');
+  };
+
+  return (
+    <St.ContentsWrapper>
+      <IcError />
+      <St.Title>{title}</St.Title>
+      <St.Button onClick={handleClickButton}>{btn_contents}</St.Button>
+    </St.ContentsWrapper>
+  );
+};
+
+const St = {
+  ContentsWrapper: styled.section`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+
+    gap: 1.9rem;
+  `,
+
+  Title: styled.p`
+    color: ${({ theme }) => theme.colors.gray8};
+    ${({ theme }) => theme.fonts.title_semibold_18};
+  `,
+
+  Button: styled.button`
+    width: fit-content;
+    padding: 1.2rem 1.8rem;
+
+    border-radius: 0.6rem;
+    background-color: ${({ theme }) => theme.colors.pink1};
+
+    color: ${({ theme }) => theme.colors.pink5};
+    ${({ theme }) => theme.fonts.title_semibold_16};
+  `,
+};
+
+export default PreventAccess;

--- a/src/constants/PreventAccessInfo.ts
+++ b/src/constants/PreventAccessInfo.ts
@@ -1,2 +1,8 @@
-export const TITLE = ['정보를 불러올 수 없어요', '세션이 만료되었어요'];
-export const BTN_CONTENTS = ['다시 불러오기', '홈으로 돌아가기']
+export const TITLE = {
+  error: '정보를 불러올 수 없어요',
+  expiration: '세션이 만료되었어요',
+};
+export const BTN_CONTENTS = {
+  error: '다시 불러오기',
+  expiration: '홈으로 돌아가기',
+};

--- a/src/constants/PreventAccessInfo.ts
+++ b/src/constants/PreventAccessInfo.ts
@@ -1,0 +1,2 @@
+export const TITLE = ['정보를 불러올 수 없어요', '세션이 만료되었어요'];
+export const BTN_CONTENTS = ['다시 불러오기', '홈으로 돌아가기']

--- a/src/pages/Error/ErrorPage.tsx
+++ b/src/pages/Error/ErrorPage.tsx
@@ -2,7 +2,7 @@ import PreventAccess from '../../common/PreventAccess/PreventAccess';
 import { TITLE, BTN_CONTENTS } from '../../constants/PreventAccessInfo';
 
 const ErrorPage = () => {
-  return <PreventAccess title={TITLE.error} btn_contents={BTN_CONTENTS.error} isError={true}/>;
+  return <PreventAccess title={TITLE.error} btnContents={BTN_CONTENTS.error} isError={true}/>;
 };
 
 export default ErrorPage;

--- a/src/pages/Error/ErrorPage.tsx
+++ b/src/pages/Error/ErrorPage.tsx
@@ -1,0 +1,8 @@
+import PreventAccess from '../../common/PreventAccess/PreventAccess';
+import { TITLE, BTN_CONTENTS } from '../../constants/PreventAccessInfo';
+
+const ErrorPage = () => {
+  return <PreventAccess title={TITLE[0]} btn_contents={BTN_CONTENTS[0]} isError={true}/>;
+};
+
+export default ErrorPage;

--- a/src/pages/Error/ErrorPage.tsx
+++ b/src/pages/Error/ErrorPage.tsx
@@ -2,7 +2,7 @@ import PreventAccess from '../../common/PreventAccess/PreventAccess';
 import { TITLE, BTN_CONTENTS } from '../../constants/PreventAccessInfo';
 
 const ErrorPage = () => {
-  return <PreventAccess title={TITLE[0]} btn_contents={BTN_CONTENTS[0]} isError={true}/>;
+  return <PreventAccess title={TITLE.error} btn_contents={BTN_CONTENTS.error} isError={true}/>;
 };
 
 export default ErrorPage;

--- a/src/pages/Expiration/ExpirationPage.tsx
+++ b/src/pages/Expiration/ExpirationPage.tsx
@@ -2,7 +2,7 @@ import PreventAccess from '../../common/PreventAccess/PreventAccess';
 import { BTN_CONTENTS, TITLE } from '../../constants/PreventAccessInfo';
 
 const ExpirationPage = () => {
-  return <PreventAccess title={TITLE.expiration} btn_contents={BTN_CONTENTS.expiration} />;
+  return <PreventAccess title={TITLE.expiration} btnContents={BTN_CONTENTS.expiration} />;
 };
 
 export default ExpirationPage;

--- a/src/pages/Expiration/ExpirationPage.tsx
+++ b/src/pages/Expiration/ExpirationPage.tsx
@@ -2,7 +2,7 @@ import PreventAccess from '../../common/PreventAccess/PreventAccess';
 import { BTN_CONTENTS, TITLE } from '../../constants/PreventAccessInfo';
 
 const ExpirationPage = () => {
-  return <PreventAccess title={TITLE[1]} btn_contents={BTN_CONTENTS[1]} />;
+  return <PreventAccess title={TITLE.expiration} btn_contents={BTN_CONTENTS.expiration} />;
 };
 
 export default ExpirationPage;

--- a/src/pages/Expiration/ExpirationPage.tsx
+++ b/src/pages/Expiration/ExpirationPage.tsx
@@ -1,0 +1,8 @@
+import PreventAccess from '../../common/PreventAccess/PreventAccess';
+import { BTN_CONTENTS, TITLE } from '../../constants/PreventAccessInfo';
+
+const ExpirationPage = () => {
+  return <PreventAccess title={TITLE[1]} btn_contents={BTN_CONTENTS[1]} />;
+};
+
+export default ExpirationPage;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #155 

## 💜 작업 내용
- [x] 공통 컴포넌트 분리
- [x] 에러 페이지 구현
- [x] 만료 페이지 구현

## ✅ PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
        - 각 페이지에 들어갈 내용은 상수로 관리
    
    ```
    export const TITLE = ['정보를 불러올 수 없어요', '세션이 만료되었어요'];
    export const BTN_CONTENTS = ['다시 불러오기', '홈으로 돌아가기']
    ```

    - 공통 컴포넌트 구현
    
    ```
    <St.ContentsWrapper>
      <IcError />
      <St.Title>{title}</St.Title>
      <St.Button onClick={handleClickButton}>{btn_contents}</St.Button>
    </St.ContentsWrapper>
    ```

    - `isError`로 에러/ 만료 페이지 구분 -> 버튼 기능 구현
    
    ```
    const handleClickButton = () => {
    isError ? window.location.reload() : navigate('/');
    };
    ```

## ☀️ 스크린샷 / GIF / 화면 녹화 

- `새로고침`되는 것 보세용

https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/d867eb90-09fa-4173-8812-3de489d199c0

https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/6cd23058-2c81-4ddf-9989-414873458cdf



