### PR TITLE
[ChargePage] 포인트 충전 뷰 레이아웃 + 버튼 비활성화 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,7 +36,7 @@ const St = {
   `,
 
   title: styled.h1`
-    font: ${({ theme }) => theme.fonts.title_semibold_18};
+    ${({ theme }) => theme.fonts.title_semibold_18};
   `,
 };
 

--- a/src/components/PointCharge/Charge.tsx
+++ b/src/components/PointCharge/Charge.tsx
@@ -1,8 +1,12 @@
 import { styled } from 'styled-components';
 import { IcCheckSmallGray } from '../../assets/icon';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
-const Charge = () => {
+const Charge = ({
+  setIsActiveNext,
+}: {
+  setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
   const [isWarning, setIsWarning] = useState(false);
   const [parsedPrice, setParsedPrice] = useState('');
 
@@ -20,8 +24,12 @@ const Charge = () => {
     setParsedPrice(removedCommaValue.toLocaleString());
 
     //1000원 단위인지 확인
-    {
-      removedCommaValue % 1000 === 0 ? setIsWarning(false) : setIsWarning(true);
+    if (removedCommaValue % 1000 === 0) {
+      setIsWarning(false);
+      setIsActiveNext(true);
+    } else {
+      setIsWarning(true);
+      setIsActiveNext(false);
     }
   };
 

--- a/src/components/PointCharge/PointChargeFooter.tsx
+++ b/src/components/PointCharge/PointChargeFooter.tsx
@@ -1,8 +1,17 @@
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-const PointChargeFooter = () => {
+const PointChargeFooter = ({ isActiveNext }: { isActiveNext: boolean }) => {
+  const navigate = useNavigate();
+
+  const handleClickFooter = () => {
+    {
+      isActiveNext && navigate('/point-transfer');
+    }
+  };
+
   return (
-    <St.PointChargeFooter>
+    <St.PointChargeFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
       <St.FooterText>다음</St.FooterText>
     </St.PointChargeFooter>
   );
@@ -11,7 +20,7 @@ const PointChargeFooter = () => {
 export default PointChargeFooter;
 
 const St = {
-  PointChargeFooter: styled.footer`
+  PointChargeFooter: styled.footer<{ $isActiveNext: boolean }>`
     position: absolute;
     bottom: 0;
 
@@ -22,7 +31,8 @@ const St = {
     width: 100%;
     height: 7rem;
 
-    background-color: ${({ theme }) => theme.colors.gray9};
+    background-color: ${({ $isActiveNext, theme }) =>
+      $isActiveNext ? theme.colors.gray9 : theme.colors.gray3};
   `,
 
   FooterText: styled.p`

--- a/src/components/PointCharge/PointChargeFooter.tsx
+++ b/src/components/PointCharge/PointChargeFooter.tsx
@@ -1,0 +1,32 @@
+import { styled } from 'styled-components';
+
+const PointChargeFooter = () => {
+  return (
+    <St.PointChargeFooter>
+      <St.FooterText>다음</St.FooterText>
+    </St.PointChargeFooter>
+  );
+};
+
+export default PointChargeFooter;
+
+const St = {
+  PointChargeFooter: styled.footer`
+    position: absolute;
+    bottom: 0;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 100%;
+    height: 7rem;
+
+    background-color: ${({ theme }) => theme.colors.gray9};
+  `,
+
+  FooterText: styled.p`
+    color: ${({ theme }) => theme.colors.white};
+    ${({ theme }) => theme.fonts.title_semibold_18};
+  `,
+};

--- a/src/pages/PointCharge/ChargePage.tsx
+++ b/src/pages/PointCharge/ChargePage.tsx
@@ -1,19 +1,22 @@
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
 import Charge from '../../components/PointCharge/Charge';
 import Header from '../../components/Header';
 import PageLayout from '../../components/PageLayout';
 import ProgressBar from '../../common/ProgressBar';
 import PointChargeFooter from '../../components/PointCharge/PointChargeFooter';
+
 import { IcCancelDark } from '../../assets/icon';
 
 const ChargePage = () => {
   const navigate = useNavigate();
+  const [isActiveNext, setIsActiveNext] = useState(false);
 
   const renderChargePageHeader = () => {
     return (
       <Header
-        transparent={false}
         leftSection={<St.BlankSection></St.BlankSection>}
         title='포인트 충전'
         rightSection={<IcCancelDark onClick={() => navigate(-1)} />}
@@ -23,8 +26,12 @@ const ChargePage = () => {
   };
 
   return (
-    <PageLayout renderHeader={renderChargePageHeader} footer={<PointChargeFooter />}>
-      <Charge />
+    <PageLayout
+      renderHeader={renderChargePageHeader}
+      footer={<PointChargeFooter isActiveNext={isActiveNext} />}
+    >
+      <Charge setIsActiveNext={setIsActiveNext} />
+      <PointChargeFooter isActiveNext={isActiveNext} />
     </PageLayout>
   );
 };

--- a/src/pages/PointCharge/ChargePage.tsx
+++ b/src/pages/PointCharge/ChargePage.tsx
@@ -1,11 +1,40 @@
 import Charge from '../../components/PointCharge/Charge';
+import Header from '../../components/Header';
+import { styled } from 'styled-components';
+import { IcCancelDark } from '../../assets/icon';
+import { useNavigate } from 'react-router-dom';
+import PageLayout from '../../components/PageLayout';
+import ProgressBar from '../../common/ProgressBar';
 
 const ChargePage = () => {
+  const navigate = useNavigate();
+
+  const renderChargePageHeader = () => {
+    return (
+      <Header
+        transparent={false}
+        leftSection={<St.BlankSection></St.BlankSection>}
+        title='포인트 충전'
+        rightSection={<IcCancelDark onClick={() => navigate(-1)} />}
+        progressBar={<ProgressBar curStep={1} maxStep={3} />}
+      />
+    );
+  };
+
   return (
-    <>
+    <PageLayout renderHeader={renderChargePageHeader} footer={<></>}>
       <Charge />
-    </>
+    </PageLayout>
   );
 };
 
 export default ChargePage;
+
+const St = {
+  BlankSection: styled.div`
+    width: 2.4rem;
+    height: 2.4rem;
+
+    background-color: transparent;
+  `,
+};

--- a/src/pages/PointCharge/ChargePage.tsx
+++ b/src/pages/PointCharge/ChargePage.tsx
@@ -1,10 +1,11 @@
+import { styled } from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import Charge from '../../components/PointCharge/Charge';
 import Header from '../../components/Header';
-import { styled } from 'styled-components';
-import { IcCancelDark } from '../../assets/icon';
-import { useNavigate } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
 import ProgressBar from '../../common/ProgressBar';
+import PointChargeFooter from '../../components/PointCharge/PointChargeFooter';
+import { IcCancelDark } from '../../assets/icon';
 
 const ChargePage = () => {
   const navigate = useNavigate();
@@ -16,13 +17,13 @@ const ChargePage = () => {
         leftSection={<St.BlankSection></St.BlankSection>}
         title='포인트 충전'
         rightSection={<IcCancelDark onClick={() => navigate(-1)} />}
-        progressBar={<ProgressBar curStep={1} maxStep={3} />}
+        progressBar={<ProgressBar curStep={1} maxStep={2} />}
       />
     );
   };
 
   return (
-    <PageLayout renderHeader={renderChargePageHeader} footer={<></>}>
+    <PageLayout renderHeader={renderChargePageHeader} footer={<PointChargeFooter />}>
       <Charge />
     </PageLayout>
   );

--- a/src/pages/PointCharge/ChargePage.tsx
+++ b/src/pages/PointCharge/ChargePage.tsx
@@ -31,7 +31,6 @@ const ChargePage = () => {
       footer={<PointChargeFooter isActiveNext={isActiveNext} />}
     >
       <Charge setIsActiveNext={setIsActiveNext} />
-      <PointChargeFooter isActiveNext={isActiveNext} />
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #62

## 💜 작업 내용
- [x] 포인트 충전 뷰 헤더 푸터 페이지 레이아웃 구현
- [x] 버튼 비활성화 구현 및 navigate 구현

## ✅ PR Point
### 페이지 레이아웃
```ts
const ChargePage = () => {
  const navigate = useNavigate();
  const [isActiveNext, setIsActiveNext] = useState(false);

  const renderChargePageHeader = () => {
    return (
      <Header
        leftSection={<St.BlankSection></St.BlankSection>}
        title='포인트 충전'
        rightSection={<IcCancelDark onClick={() => navigate(-1)} />}
        progressBar={<ProgressBar curStep={1} maxStep={2} />}
      />
    );
  };

  return (
    <PageLayout
      renderHeader={renderChargePageHeader}
      footer={<PointChargeFooter isActiveNext={isActiveNext} />}
    >
      <Charge setIsActiveNext={setIsActiveNext} />
    </PageLayout>
  );
};
```

### input 검증 통과 못할시 넘어가지 않게
isActiveNext, setIsActiveNext state props로 넘겨 줘서 처리


## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/cec516bb-014e-4de9-ab80-3cb104a5581e
