### PR TITLE
[SearchPage] mainPage 아이콘 navigate 연결

### DIFF
--- a/src/components/MainPage/MainHeaderButton.tsx
+++ b/src/components/MainPage/MainHeaderButton.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import { IcMenuDark, IcMenuLight, IcSearchDark, IcSearchLight } from '../../assets/icon';
 import { SetStateAction } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface MainHeaderButtonProps {
   setIsSideMenuOpen: React.Dispatch<SetStateAction<boolean>>;
@@ -8,13 +9,19 @@ interface MainHeaderButtonProps {
 }
 
 const MainHeaderButton = ({ setIsSideMenuOpen, light }: MainHeaderButtonProps) => {
+  const navigate = useNavigate();
+
   const handleClickNavButton = () => {
     setIsSideMenuOpen(true);
   };
 
+  const handleClickSearchButton = () => {
+    navigate('/search');
+  };
+
   return (
     <St.ButtonWrapper>
-      <St.SearchButton type='button'>
+      <St.SearchButton type='button' onClick={handleClickSearchButton}>
         {light ? <IcSearchLight /> : <IcSearchDark />}
       </St.SearchButton>
       <St.NavButton type='button' onClick={handleClickNavButton}>


### PR DESCRIPTION
## 🔥 Related Issues
resolved #208 

## 💜 작업 내용
- [x] MainPage Header에 SearchPage 연결

## ✅ PR Point
```
const MainHeaderButton = ({ setIsSideMenuOpen, light }: MainHeaderButtonProps) => {
  const navigate = useNavigate();

  const handleClickNavButton = () => {
    setIsSideMenuOpen(true);
  };

  const handleClickSearchButton = () => {
    navigate('/search');
  };

  return (
    <St.ButtonWrapper>
      <St.SearchButton type='button' onClick={handleClickSearchButton}>
        {light ? <IcSearchLight /> : <IcSearchDark />}
      </St.SearchButton>
      <St.NavButton type='button' onClick={handleClickNavButton}>
        {light ? <IcMenuLight /> : <IcMenuDark />}
      </St.NavButton>
    </St.ButtonWrapper>
  );
};
```
클릭 이벤트를 추가했습니다.
## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지

## ☀️ 스크린샷 / GIF / 화면 녹화 

## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)