### PR TITLE
[CustomImg page] 디자인 수정 사항 반영 및 레이아웃 추가

### DIFF
--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -3,11 +3,15 @@ import { styled } from 'styled-components';
 import CustomImgHeader from './CustomImgHeader';
 import CustomImgAttach from './CustomImgAttach';
 
-const CustomImg = () => {
+const CustomImg = ({
+  setIsActiveNext,
+}: {
+  setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
   return (
     <St.CustomImgWrapper>
       <CustomImgHeader />
-      <CustomImgAttach />
+      <CustomImgAttach setIsActiveNext={setIsActiveNext} />
     </St.CustomImgWrapper>
   );
 };

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -1,9 +1,17 @@
 import { styled } from 'styled-components';
 import { IcCancelDark, IcPhoto } from '../../../assets/icon';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-const CustomImgAttach = () => {
+const CustomImgAttach = ({
+  setIsActiveNext,
+}: {
+  setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
   const [previewURL, setPreviewURL] = useState('');
+
+  useEffect(() => {
+    previewURL ? setIsActiveNext(true) : setIsActiveNext(false);
+  }, [previewURL]);
 
   const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -38,7 +38,7 @@ const CustomImgAttach = () => {
         </St.ImgPreviewContainer>
       ) : (
         <St.ImgAttachArea>
-          <p>도안 이미지를 첨부해주세요</p>
+          <p>투명한 배경, 고화질 png 파일 1장을 첨부해주세요</p>
         </St.ImgAttachArea>
       )}
       <label htmlFor='imgInput'>

--- a/src/components/Custom/NoDesgin/CustomImgHeader.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgHeader.tsx
@@ -7,11 +7,11 @@ const CustomImgHeader = () => {
       <St.ImgInfoTitle>그려둔 도안 이미지를 첨부해주세요</St.ImgInfoTitle>
       <St.ImgInfoDetail>
         <IcCheckSmallGray />
-        <span>선택 크기보다 0cm 이상 여유 있는 크기로 첨부해주세요</span>
+        <span>선택 크기보다 1cm 이상 여유가 필요해요</span>
       </St.ImgInfoDetail>
       <St.ImgInfoDetail>
         <IcCheckSmallGray />
-        <span>투명한 배경, 고화질 png 파일로 1장 첨부해주세요</span>
+        <span>다른 타투이스트의 도안을 첨부할 경우 저작권 문제로 신청서가 반려될 수 있어요</span>
       </St.ImgInfoDetail>
     </St.ImgInfoContainer>
   );
@@ -23,7 +23,7 @@ const St = {
   ImgInfoContainer: styled.article`
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4rem;
 
     margin: 5.6rem 0 3.6rem;
   `,
@@ -37,14 +37,21 @@ const St = {
 
   ImgInfoDetail: styled.p`
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.2rem;
 
+    white-space: pre-line;
+
     & > span {
+      max-width: 28.4rem;
       padding-top: 0.2rem;
 
       color: ${({ theme }) => theme.colors.gray3};
       ${({ theme }) => theme.fonts.body_medium_14};
     }
+  `,
+  ImgInfoDetailBox: styled.div`
+    display: flex;
+    flex-direction: column;
   `,
 };

--- a/src/pages/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/pages/Custom/NoDesign/CustomImgPage.tsx
@@ -1,10 +1,41 @@
+import { useState } from 'react';
+import BackBtn from '../../../common/Header/BackBtn';
 import CustomImg from '../../../components/Custom/NoDesgin/CustomImg';
+import Header from '../../../components/Header';
+import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
+import CancelBtn from '../../../common/Header/CancelBtn';
+import ProgressBar from '../../../common/ProgressBar';
+import PageLayout from '../../../components/PageLayout';
+import NextFooter from '../../../common/Footer/NextFooter';
 
 const CustomImgPage = () => {
+  const [modalOn, setModalOn] = useState(false);
+  const [isActiveBtn, setIsActiveBtn] = useState(false);
+
+  const renderCustomImgPageHeader = () => {
+    return (
+      <Header
+        leftSection={<BackBtn />}
+        title='커스텀 타투'
+        rightSection={
+          <CancelBtn
+            modalOn={modalOn}
+            setModalOn={setModalOn}
+            targetModal={<CustomSizeEscapeModal setModalOn={setModalOn} />}
+          />
+        }
+        progressBar={<ProgressBar curStep={2} maxStep={5} />}
+      />
+    );
+  };
+
   return (
-    <>
-      <CustomImg />
-    </>
+    <PageLayout
+      renderHeader={renderCustomImgPageHeader}
+      footer={<NextFooter isActiveBtn={isActiveBtn} navigateURL='/custom-request' />}
+    >
+      <CustomImg setIsActiveBtn={setIsActiveBtn} />
+    </PageLayout>
   );
 };
 

--- a/src/pages/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/pages/Custom/NoDesign/CustomImgPage.tsx
@@ -10,7 +10,7 @@ import NextFooter from '../../../common/Footer/NextFooter';
 
 const CustomImgPage = () => {
   const [modalOn, setModalOn] = useState(false);
-  const [isActiveBtn, setIsActiveBtn] = useState(false);
+  const [isActiveNext, setIsActiveNext] = useState(false);
 
   const renderCustomImgPageHeader = () => {
     return (
@@ -32,9 +32,9 @@ const CustomImgPage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomImgPageHeader}
-      footer={<NextFooter isActiveBtn={isActiveBtn} navigateURL='/custom-request' />}
+      footer={<NextFooter isActiveNext={isActiveNext} navigateURL='/custom-request' />}
     >
-      <CustomImg setIsActiveBtn={setIsActiveBtn} />
+      <CustomImg setIsActiveNext={setIsActiveNext} />
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #211 

## 💜 작업 내용
- [x] UX 라이팅 수정 사항 반영
- [x] 페이지레이아웃, 버튼 검증 추가

## ✅ PR Point
- 버튼 활성화, 비활성화
```tsx
const CustomImgAttach = ({
  setIsActiveNext,
}: {
  setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
}) => {
  const [previewURL, setPreviewURL] = useState('');

  useEffect(() => {
    previewURL ? setIsActiveNext(true) : setIsActiveNext(false);
  }, [previewURL]);

```
preveiwURL의 존재가 있는지 없는지에 따라 버튼 활성화/비활성화 구현

## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/5eab4574-2dda-417a-ba0e-cfb4b3654ad2

