### PR TITLE
[Detail Page] 모든 navigation

### DIFF
--- a/src/components/Detail/DetailCarousel.tsx
+++ b/src/components/Detail/DetailCarousel.tsx
@@ -14,12 +14,10 @@ const DetailCarousel = ({ isCustom }: { isCustom: boolean }) => {
       <Swiper modules={[Pagination]} pagination={{ clickable: true }} slidesPerView={1} loop={true}>
         {DATA.map((el, index) => (
           <SwiperSlide key={index}>
-            {isCustom ? (
+            {isCustom && (
               <St.CustomLabel>
                 <LabelCustomSmall />
               </St.CustomLabel>
-            ) : (
-              ''
             )}
             <St.Card>{el}</St.Card>
           </SwiperSlide>

--- a/src/components/Detail/DetailCarousel.tsx
+++ b/src/components/Detail/DetailCarousel.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination } from 'swiper/modules';
+import { LabelCustomSmall } from '../../assets/icon';
 
-const DetailCarousel = () => {
+const DetailCarousel = ({ isCustom }: { isCustom: boolean }) => {
   const DATA = ['Slide 1', 'Slide 2', 'Slide 3'];
 
   return (
@@ -13,6 +14,13 @@ const DetailCarousel = () => {
       <Swiper modules={[Pagination]} pagination={{ clickable: true }} slidesPerView={1} loop={true}>
         {DATA.map((el, index) => (
           <SwiperSlide key={index}>
+            {isCustom ? (
+              <St.CustomLabel>
+                <LabelCustomSmall />
+              </St.CustomLabel>
+            ) : (
+              ''
+            )}
             <St.Card>{el}</St.Card>
           </SwiperSlide>
         ))}
@@ -55,5 +63,8 @@ const St = {
 
     background-color: ${({ theme }) => theme.colors.gray0};
     color: black;
+  `,
+  CustomLabel: styled.div`
+    position: absolute;
   `,
 };

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { IcHeartDark, IcHeartLight } from '../../assets/icon';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 
 interface DetailFooterProp {
   setSheetOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -14,11 +15,11 @@ const DetailFooter = ({ setSheetOpen, isSecond, text, like, setLike }: DetailFoo
 
   const handleClickButton = () => {
     if (text === '충전하기') {
-      // 충전하기 뷰로 navigate
-      console.log('충전하기 이동');
+      // state 하나 넘겨줘야함. 추후 추가 예정
+      navigate('/point-charge');
     } else if (isSecond) {
-      // navigate('/order');
-      console.log('구매하기 이동');
+      // 추후 아이템 인덱스도 함께 전달
+      navigate('/order');
     } else {
       setSheetOpen(true);
     }

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -9,6 +9,8 @@ import { useState } from 'react';
 import DetailBottom from '../components/Detail/DetailBottom';
 import CustomScrollContainer from '../common/CustomScrollContainer';
 import SmallTattooCard from '../common/SmallTattooCard';
+import BackBtn from '../common/Header/BackBtn';
+import CancelBtn from '../common/Header/CancelBtn';
 
 const DUMMY_DATA = [
   {
@@ -74,7 +76,7 @@ const DetailPage = () => {
   const [like, setLike] = useState(false); // 찜 여부 state
 
   const renderDetailPageHeader = () => {
-    return <Header leftSection={<IcBackDark />} rightSection={<IcCancelDark />} />;
+    return <Header leftSection={<BackBtn />} />;
   };
 
   return (

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -8,6 +8,7 @@ import DetailBottom from '../components/Detail/DetailBottom';
 import CustomScrollContainer from '../common/CustomScrollContainer';
 import SmallTattooCard from '../common/SmallTattooCard';
 import BackBtn from '../common/Header/BackBtn';
+import { useNavigate } from 'react-router-dom';
 
 const DUMMY_DATA = [
   {
@@ -69,8 +70,12 @@ const DUMMY_DATA = [
 ];
 
 const DetailPage = () => {
-  const [isSheetOpen, setSheetOpen] = useState(false); // bottomsheet를 위한 state
-  const [like, setLike] = useState(false); // 찜 여부 state
+  const navigate = useNavigate();
+  const [isSheetOpen, setSheetOpen] = useState(false);
+  const [isCustom, setCustom] = useState(false); // 해당 상품이 custom인지 여부
+
+  // 찜 여부 state -> 추후 서버통신
+  const [like, setLike] = useState(false);
 
   const renderDetailPageHeader = () => {
     return <Header leftSection={<BackBtn />} />;
@@ -89,7 +94,7 @@ const DetailPage = () => {
         />
       }
     >
-      <DetailCarousel />
+      <DetailCarousel isCustom={isCustom} />
       <DetailInfo />
       <CustomScrollContainer title='비슷한 제품도 추천드려요'>
         {DUMMY_DATA.map((el, index) => (

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,16 +1,13 @@
-import styled from 'styled-components';
 import DetailInfo from '../components/Detail/DetailInfo';
 import DetailCarousel from '../components/Detail/DetailCarousel';
 import PageLayout from '../components/PageLayout';
 import Header from '../components/Header';
-import { IcBackDark, IcCancelDark } from '../assets/icon';
 import DetailFooter from '../components/Detail/DetailFooter';
 import { useState } from 'react';
 import DetailBottom from '../components/Detail/DetailBottom';
 import CustomScrollContainer from '../common/CustomScrollContainer';
 import SmallTattooCard from '../common/SmallTattooCard';
 import BackBtn from '../common/Header/BackBtn';
-import CancelBtn from '../common/Header/CancelBtn';
 
 const DUMMY_DATA = [
   {


### PR DESCRIPTION
## 🔥 Related Issues
resolved #226 

## 💜 작업 내용
- [x] 상세 페이지 Custom 여부에 따라 라벨링 조건부 렌더링 
- [x] Detail 구매하기/충전하기 navigation (추후 전달할 props 추가해야함) 
- [x] 뒤로가기 버튼 아이콘->유틸 컴포넌트로 이동 

## ✅ PR Point
- custom 라벨링 조건부 렌더링
  - DetailPage에서 서버를 통해 받아오는 isCustom state를 DetailCarousel로 전달
  - 전달된 state에 따라 라벨 조건부 렌더링 
- Detail 구매하기/충전하기 navigation
  - Footer의 handleClickButton에서 충전하기/구매하기에 따라 navigate 시켜줌
  - 전달해야할 state가 있다고 해서 나중에 추가 예정 
- 뒤로가기 버튼 
  - <Ic어쩌구/> 에서 유틸 붙어있는 <BackBtn/> 컴포넌트로 바꿔줌 