### PR TITLE
[SelectPage] 🚨 최소 사이즈 맞춰서 뷰 수정

### DIFF
--- a/src/components/Custom/SelectCustom.tsx
+++ b/src/components/Custom/SelectCustom.tsx
@@ -82,6 +82,8 @@ const St = {
     flex-direction: column;
     justify-content: center;
 
+    padding: 0 2.75rem;
+
     width: 100%;
     height: calc(
       100dvh - 24.8rem
@@ -105,7 +107,6 @@ const St = {
   InfoMainText: styled.h2`
     color: ${({ theme }) => theme.colors.gray8};
     ${({ theme }) => theme.fonts.title_semibold_20};
-    padding: 0 6rem;
   `,
 
   SelectBtnContainer: styled.article`

--- a/src/components/Custom/SelectCustom.tsx
+++ b/src/components/Custom/SelectCustom.tsx
@@ -97,9 +97,15 @@ const St = {
   SelectWrapper: styled.section`
     display: flex;
     flex-direction: column;
+    justify-content: center;
 
     width: 100%;
-    /* height: 100vh; */
+    height: calc(100svh - 13rem);
+  `,
+
+  SelectTopSectionContainerWrapper: styled.section`
+    display: flex;
+    flex-direction: column;
   `,
 
   SelectInfoContainer: styled.article`
@@ -108,7 +114,7 @@ const St = {
     align-items: center;
     gap: 1.2rem;
 
-    margin: 14.8rem 0 4rem;
+    margin: 5.6rem 0 4rem; //최상단 세로 마진
   `,
 
   InfoMainText: styled.h2`
@@ -120,7 +126,9 @@ const St = {
   SelectBtnContainer: styled.article`
     display: flex;
     gap: 1.5rem;
-    padding: 0 2rem;
+    justify-content: center;
+
+    width: 100%;
   `,
 
   SelectCustomPolicyContainer: styled.article`
@@ -128,7 +136,7 @@ const St = {
     flex-direction: column;
     gap: 1rem;
 
-    margin-top: 11.7rem;
+    margin: 9.6rem 0 3.8rem 0; //정책 동의 영역과 버튼 사이 마진
     padding-left: 2.4rem;
   `,
 

--- a/src/components/Custom/SelectCustom.tsx
+++ b/src/components/Custom/SelectCustom.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { styled } from 'styled-components';
 import SelectCustomBtn from './SelectCustomBtn';
-import { IcArrowRightDark } from '../../assets/icon';
-import SelectCustomPolicyBottom from './SelectCustomPolicyBottom';
 
 const SelectCustom = ({
   setIsActiveNext,
@@ -29,8 +27,6 @@ const SelectCustom = ({
   const [activeBtn, setActiveBtn] = useState(''); //선택 된 버튼의 상황
   const btnRef = useRef<HTMLButtonElement[]>([]); //상황 선택 버튼 리스트 ref
   const [haveDesign, setHaveDesign] = useState<boolean>(); //리코일 저장 후 서버 통신 예정
-
-  const [isSheetOpen, setSheetOpen] = useState(false);
 
   const handleClickSelBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
     const target = e.target as HTMLElement;
@@ -74,19 +70,6 @@ const SelectCustom = ({
           );
         })}
       </St.SelectBtnContainer>
-      <St.SelectCustomPolicyContainer>
-        <St.PolicyAgreeTouchArea onClick={() => setSheetOpen(true)}>
-          <St.PolicyAgreeMainText>커스텀 도안 환불 정책에 동의합니다</St.PolicyAgreeMainText>
-          <IcArrowRightDark />
-        </St.PolicyAgreeTouchArea>
-        <St.PolicyAgreeSubTextBox>
-          <St.PolicyAgreeSubText>
-            다음 페이지로 넘어가 신청서 작성을 시작하면 커스텀
-          </St.PolicyAgreeSubText>
-          <St.PolicyAgreeSubText>도안 정책에 동의하는 것으로 간주합니다</St.PolicyAgreeSubText>
-        </St.PolicyAgreeSubTextBox>
-        <SelectCustomPolicyBottom isSheetOpen={isSheetOpen} setSheetOpen={setSheetOpen} />
-      </St.SelectCustomPolicyContainer>
     </St.SelectWrapper>
   );
 };
@@ -100,7 +83,9 @@ const St = {
     justify-content: center;
 
     width: 100%;
-    height: calc(100svh - 13rem);
+    height: calc(
+      100dvh - 24.8rem
+    ); //탭 바 제외 높이 - (헤더 영역 + 정책 영역 + cta 푸터 영역 높이 값)
   `,
 
   SelectTopSectionContainerWrapper: styled.section`
@@ -129,36 +114,5 @@ const St = {
     justify-content: center;
 
     width: 100%;
-  `,
-
-  SelectCustomPolicyContainer: styled.article`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-
-    margin: 9.6rem 0 3.8rem 0; //정책 동의 영역과 버튼 사이 마진
-    padding-left: 2.4rem;
-  `,
-
-  PolicyAgreeTouchArea: styled.article`
-    display: flex;
-    gap: 0.3rem;
-
-    cursor: pointer;
-  `,
-
-  PolicyAgreeMainText: styled.p`
-    color: ${({ theme }) => theme.colors.gray4};
-    ${({ theme }) => theme.fonts.body_medium_16};
-  `,
-
-  PolicyAgreeSubTextBox: styled.div`
-    display: flex;
-    flex-direction: column;
-  `,
-
-  PolicyAgreeSubText: styled.p`
-    color: ${({ theme }) => theme.colors.gray2};
-    ${({ theme }) => theme.fonts.body_medium_14};
   `,
 };

--- a/src/components/Custom/SelectCustomPolicy.tsx
+++ b/src/components/Custom/SelectCustomPolicy.tsx
@@ -1,0 +1,62 @@
+import { styled } from 'styled-components';
+import { IcArrowRightDark } from '../../assets/icon';
+import SelectCustomPolicyBottom from './SelectCustomPolicyBottom';
+import { useState } from 'react';
+
+const SelectCustomPolicy = () => {
+  const [isSheetOpen, setSheetOpen] = useState(false);
+
+  return (
+    <St.SelectCustomPolicyWrapper>
+      <St.PolicyAgreeTouchArea onClick={() => setSheetOpen(true)}>
+        <St.PolicyAgreeMainText>커스텀 도안 환불 정책에 동의합니다</St.PolicyAgreeMainText>
+        <IcArrowRightDark />
+      </St.PolicyAgreeTouchArea>
+      <St.PolicyAgreeSubTextBox>
+        <St.PolicyAgreeSubText>
+          다음 페이지로 넘어가 신청서 작성을 시작하면 커스텀
+        </St.PolicyAgreeSubText>
+        <St.PolicyAgreeSubText>도안 정책에 동의하는 것으로 간주합니다</St.PolicyAgreeSubText>
+      </St.PolicyAgreeSubTextBox>
+      <SelectCustomPolicyBottom isSheetOpen={isSheetOpen} setSheetOpen={setSheetOpen} />
+    </St.SelectCustomPolicyWrapper>
+  );
+};
+
+export default SelectCustomPolicy;
+
+const St = {
+  SelectCustomPolicyWrapper: styled.article`
+    position: sticky;
+    bottom: 7rem;
+
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    height: 12.2rem;
+    padding: 2.6rem 0 2.9rem 2.2rem;
+  `,
+
+  PolicyAgreeTouchArea: styled.article`
+    display: flex;
+    gap: 0.3rem;
+
+    cursor: pointer;
+  `,
+
+  PolicyAgreeMainText: styled.p`
+    color: ${({ theme }) => theme.colors.gray4};
+    ${({ theme }) => theme.fonts.body_medium_16};
+  `,
+
+  PolicyAgreeSubTextBox: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  PolicyAgreeSubText: styled.p`
+    color: ${({ theme }) => theme.colors.gray2};
+    ${({ theme }) => theme.fonts.body_medium_14};
+  `,
+};

--- a/src/components/Custom/SelectCustomPolicy.tsx
+++ b/src/components/Custom/SelectCustomPolicy.tsx
@@ -35,8 +35,7 @@ const St = {
     gap: 1rem;
 
     height: 12.2rem;
-    padding: 0 2.75rem;
-    margin: 2.6rem 0 2.9rem 2.2rem;
+    padding: 2.6rem 0 2.9rem 4.95rem;
   `,
 
   PolicyAgreeTouchArea: styled.article`

--- a/src/components/Custom/SelectCustomPolicy.tsx
+++ b/src/components/Custom/SelectCustomPolicy.tsx
@@ -26,7 +26,7 @@ const SelectCustomPolicy = () => {
 export default SelectCustomPolicy;
 
 const St = {
-  SelectCustomPolicyWrapper: styled.article`
+  SelectCustomPolicyWrapper: styled.section`
     position: sticky;
     bottom: 7rem;
 
@@ -35,7 +35,8 @@ const St = {
     gap: 1rem;
 
     height: 12.2rem;
-    padding: 2.6rem 0 2.9rem 2.2rem;
+    padding: 0 2.75rem;
+    margin: 2.6rem 0 2.9rem 2.2rem;
   `,
 
   PolicyAgreeTouchArea: styled.article`

--- a/src/pages/Custom/SelectPage.tsx
+++ b/src/pages/Custom/SelectPage.tsx
@@ -6,6 +6,7 @@ import PageLayout from '../../components/PageLayout';
 import { IcCancelDark } from '../../assets/icon';
 import { useNavigate } from 'react-router-dom';
 import SelectCustomFooter from '../../components/Custom/SelectCustomFooter';
+import SelectCustomPolicy from '../../components/Custom/SelectCustomPolicy';
 
 const SelectPage = () => {
   const navigate = useNavigate();
@@ -28,6 +29,7 @@ const SelectPage = () => {
       footer={<SelectCustomFooter isActiveNext={isActiveNext} />}
     >
       <SelectCustom setIsActiveNext={setIsActiveNext} />
+      <SelectCustomPolicy />
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #231 

## 💜 작업 내용
- [x] 최소 사이즈 맞춰서 뷰 수정

## ✅ PR Point
- se 사이즈 맞춰서 뷰 수정 => 정책 영역은 하단 고정 되고, se보다 큰 사이즈 뷰에서는 상황 선택 버튼이 중앙 정렬 될 수 있도록 구현
```ts
const St = {
  SelectWrapper: styled.section`
    display: flex;
    flex-direction: column;
    justify-content: center;

    padding: 0 2.75rem;

    width: 100%;
    height: calc(
      100dvh - 24.8rem
    ); //탭 바 제외 높이 - (헤더 영역 + 정책 영역 + cta 푸터 영역 높이 값)
  `,
```
* 탭바 제외한 높이 값을 구해주는 dvh 단위 사용 , 헤더, 정책 영역, cta 푸터 영역 높이 값을 빼서 구현


-정렬 문제 때문에 375사이즈 맞춰서 뷰 짰음 => QA 때 같이 맞춰보고 수정 필요

## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="310" alt="Pasted Graphic" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/2d04659b-d3ab-49d8-af6c-da13fa3589cb">
<img width="310" alt="Pasted Graphic 1" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/ef73f21f-4d68-4626-ac14-57d5691b1ef6">
