### PR TITLE
[TransferPage] 송금페이지 레이아웃 수정, hr 제거, 모달 연결

### DIFF
--- a/src/components/PointCharge/AccountCopy.tsx
+++ b/src/components/PointCharge/AccountCopy.tsx
@@ -30,6 +30,8 @@ export default AccountCopy;
 const St = {
   TransferAccountContainer: styled.article`
     width: 100%;
+    display: flex;
+    justify-content: center;
   `,
 
   AccountBox: styled.div`

--- a/src/components/PointCharge/PointTransferFooter.tsx
+++ b/src/components/PointCharge/PointTransferFooter.tsx
@@ -24,9 +24,8 @@ export default PointTransferFooter;
 
 const St = {
   TransferFooter: styled.footer<{ $isActiveNext: boolean }>`
-    position: absolute;
+    position: sticky;
     bottom: 0;
-    left: 0;
 
     display: flex;
     justify-content: center;

--- a/src/components/PointCharge/PointTransferFooter.tsx
+++ b/src/components/PointCharge/PointTransferFooter.tsx
@@ -1,18 +1,22 @@
-import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import CheckModal from '../../common/Modal/CheckModal/CheckModal';
+import { useState } from 'react';
 
 const PointTransferFooter = ({ isActiveNext }: { isActiveNext: boolean }) => {
-  const navigate = useNavigate();
+  const [modalOn, setModalOn] = useState(false);
 
   const handleClickFooter = () => {
     //여기 수정 필요 -> 포인트 충전으로 들어오기 전 url로 보내기
-    isActiveNext && navigate('/');
+    isActiveNext && setModalOn(true);
   };
 
   return (
-    <St.TransferFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
-      <St.FooterText>송금했어요</St.FooterText>
-    </St.TransferFooter>
+    <>
+      <St.TransferFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
+        <St.FooterText>송금했어요</St.FooterText>
+      </St.TransferFooter>
+      {modalOn && <CheckModal setModalOn={setModalOn} />}
+    </>
   );
 };
 
@@ -20,7 +24,7 @@ export default PointTransferFooter;
 
 const St = {
   TransferFooter: styled.footer<{ $isActiveNext: boolean }>`
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
 

--- a/src/components/PointCharge/TransferMain.tsx
+++ b/src/components/PointCharge/TransferMain.tsx
@@ -2,11 +2,7 @@ import { styled } from 'styled-components';
 import AccountCopy from './AccountCopy';
 import TransferPolicy from './TransferPolicy';
 
-const TransferMain = ({
-  setIsActiveNext,
-}: {
-  setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
-}) => {
+const TransferMain = () => {
   const chargedCost = 3000;
 
   return (
@@ -27,10 +23,6 @@ const TransferMain = ({
         </St.InfoPriceMain>
         <AccountCopy />
       </St.TransferInfoContainer>
-      <St.TransferPolicyArea>
-        <St.TransferSectionDivide />
-        <TransferPolicy setIsActiveNext={setIsActiveNext} />
-      </St.TransferPolicyArea>
     </St.TransferMainWrapper>
   );
 };
@@ -41,10 +33,10 @@ const St = {
   TransferMainWrapper: styled.section`
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: flex-start;
+    align-items: center;
 
-    min-height: calc(var(--vh, 1vh) * 100);
-    padding: 6rem 0 7rem 0;
+    height: calc(100dvh - 21.6rem);
   `,
 
   TransferInfoContainer: styled.article`
@@ -103,19 +95,5 @@ const St = {
   RightUnit: styled.span`
     color: ${({ theme }) => theme.colors.gray4};
     ${({ theme }) => theme.fonts.body_medium_16};
-  `,
-
-  TransferPolicyArea: styled.div`
-    width: var(--app-max-width, 37.5rem);
-    position: fixed;
-    bottom: 7rem;
-  `,
-
-  TransferSectionDivide: styled.hr`
-    height: 1.3rem;
-
-    border: none;
-
-    background-color: ${({ theme }) => theme.colors.bg};
   `,
 };

--- a/src/components/PointCharge/TransferPolicy.tsx
+++ b/src/components/PointCharge/TransferPolicy.tsx
@@ -36,9 +36,12 @@ export default TransferPolicy;
 
 const St = {
   TransferPolicyWrapper: styled.section`
+    position: sticky;
+    bottom: 7rem;
+
     display: flex;
     gap: 1.1rem;
-    padding: 3.1rem 0 4rem 2rem;
+    padding: 2.6rem 0 3.1rem 2rem;
   `,
 
   PolicyAgreeCheckBox: styled.input`

--- a/src/pages/pointCharge/TransferPage.tsx
+++ b/src/pages/pointCharge/TransferPage.tsx
@@ -7,6 +7,7 @@ import PageLayout from '../../components/PageLayout';
 import PointTransferFooter from '../../components/PointCharge/PointTransferFooter';
 import TransferMain from '../../components/PointCharge/TransferMain';
 import ChargePointEscapeModal from '../../common/Modal/EscapeModal/ChargePointEscapeModal';
+import TransferPolicy from '../../components/PointCharge/TransferPolicy';
 // import TransferPolicy from '../../components/PointCharge/TransferPolicy';
 
 const TransferPage = () => {
@@ -16,7 +17,6 @@ const TransferPage = () => {
   const renderTransferPageHeader = () => {
     return (
       <Header
-        fixed={true}
         leftSection={<BackBtn />}
         title='포인트 충전'
         rightSection={
@@ -26,7 +26,7 @@ const TransferPage = () => {
             targetModal={<ChargePointEscapeModal setModalOn={setModalOn} />}
           />
         }
-        progressBar={<ProgressBar curStep={2} maxStep={5} />}
+        progressBar={<ProgressBar curStep={2} maxStep={2} />}
       />
     );
   };
@@ -36,7 +36,8 @@ const TransferPage = () => {
       renderHeader={renderTransferPageHeader}
       footer={<PointTransferFooter isActiveNext={isActiveNext} />}
     >
-      <TransferMain setIsActiveNext={setIsActiveNext} />
+      <TransferMain />
+      <TransferPolicy setIsActiveNext={setIsActiveNext} />
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #255

## 💜 작업 내용
- [x] 송금페이지 레이아웃 웹 뷰 사이즈 맞춰 수정
- [x] hr 제거
- [x] 송금했어요 -> 버튼 클릭시 모달 뜨도록 수정 (나중에 navigate 할 URL 넘겨줘야 함)

## ✅ PR Point
- 웹 뷰 사이즈 맞춰 수정
```ts
  TransferMainWrapper: styled.section`
    display: flex;
    flex-direction: column;
    align-items: center;

    height: calc(100dvh - 21.6rem);
  `,
```

- Footer 클릭시 모달 뜨도록
```tsx
const PointTransferFooter = ({ isActiveNext }: { isActiveNext: boolean }) => {
  const [modalOn, setModalOn] = useState(false);

  const handleClickFooter = () => {
    //여기 수정 필요 -> 포인트 충전으로 들어오기 전 url로 보내기
    isActiveNext && setModalOn(true);
  };

  return (
    <>
      <St.TransferFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
        <St.FooterText>송금했어요</St.FooterText>
      </St.TransferFooter>
      {modalOn && <CheckModal setModalOn={setModalOn} />}
    </>
  );
};

export default PointTransferFooter;
```

## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지

## ☀️ 스크린샷 / GIF / 화면 녹화 

## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)