### PR TITLE
[SelectKeywordPage] 클릭시 모양 바뀌는 문제 해결 및 개수 따른 버튼 활성화 적용

### DIFF
--- a/src/components/Custom/HaveDesign/SelectKeyword.tsx
+++ b/src/components/Custom/HaveDesign/SelectKeyword.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { IcCheckSmallPink } from '../../../assets/icon';
 import { KEYWORDS_GENRE } from '../../../assets/data/KEYWORDS_GENRE';
 import { KEYWORDS_STYLE } from '../../../assets/data/KEYWORDS_STYLE';
 
-const SelectKeyword = () => {
+const SelectKeyword = ({
+  setIsActiveNext,
+}: {
+  setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
   const [genreKeywords, setGenreKeywords] = useState(KEYWORDS_GENRE);
   const [styleKeywords, setStyleKeywords] = useState(KEYWORDS_STYLE);
 
@@ -12,11 +16,12 @@ const SelectKeyword = () => {
     const checkedStyle = styleKeywords.filter((keyword) => keyword.checked).length;
     const checkedGenre = genreKeywords.filter((keyword) => keyword.checked).length;
     const checkedKeywords = checkedStyle + checkedGenre;
+
     if (type === 'genre') {
       const updatedKeywords = [...genreKeywords];
       //전체 개수 제한
       if (checkedKeywords >= 3 && updatedKeywords[index].checked === false) {
-        alert('스타일 최소 1개, 전체 최대 3개 선택 가능합니다.');
+        return;
       } else {
         updatedKeywords[index].checked = !updatedKeywords[index].checked;
         setGenreKeywords(updatedKeywords);
@@ -25,13 +30,22 @@ const SelectKeyword = () => {
       const updatedKeywords = [...styleKeywords];
       //개수 제한
       if (checkedKeywords >= 3 && updatedKeywords[index].checked === false) {
-        alert('스타일 최소 1개, 전체 최대 3개 선택 가능합니다.');
+        return;
       } else {
         updatedKeywords[index].checked = !updatedKeywords[index].checked;
         setStyleKeywords(updatedKeywords);
       }
     }
   };
+
+  useEffect(() => {
+    const checkedStyle = styleKeywords.filter((keyword) => keyword.checked).length;
+    const checkedGenre = genreKeywords.filter((keyword) => keyword.checked).length;
+    const checkedKeywords = checkedStyle + checkedGenre;
+
+    setIsActiveNext(checkedKeywords >= 1);
+  }, [genreKeywords, styleKeywords, setIsActiveNext]);
+
   return (
     <St.KeywordWrapper>
       <St.Title>장르</St.Title>
@@ -53,7 +67,7 @@ const SelectKeyword = () => {
         ))}
       </St.RadioWrapper>
       <St.Title>스타일</St.Title>
-      <St.RadioWrapper>
+      <St.RadioWrapper className='style-keywords'>
         {styleKeywords.map(({ value, checked }, index: number) => (
           <St.RadioLabel key={index} htmlFor={value} checked={checked}>
             <St.RadioInput
@@ -85,6 +99,15 @@ const St = {
 
     width: 100%;
     padding-left: 2rem;
+    min-height: calc(100dvh - 28.8rem);
+
+    .style-keywords {
+      width: 26rem;
+      gap: 1.2rem;
+
+      display: flex;
+      flex-wrap: wrap;
+    }
   `,
   Title: styled.h3`
     ${({ theme }) => theme.fonts.body_semibold_14};
@@ -95,7 +118,7 @@ const St = {
     flex-wrap: wrap;
     gap: 1rem;
 
-    width: 100%;
+    width: 33.9rem;
   `,
   RadioLabel: styled.label<{ checked: boolean }>`
     display: flex;

--- a/src/pages/Custom/HaveDesign/SelectKeywordPage.tsx
+++ b/src/pages/Custom/HaveDesign/SelectKeywordPage.tsx
@@ -7,9 +7,12 @@ import Header from '../../../components/Header';
 import ProgressBar from '../../../common/ProgressBar';
 import SelectKeyword from '../../../components/Custom/HaveDesign/SelectKeyword';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
+import NextFooter from '../../../common/Footer/NextFooter';
 
 const SelectKeywordPage = () => {
   const [modalOn, setModalOn] = useState(false);
+  const [isActiveNext, setIsActiveNext] = useState(false);
+
   const renderSelectKeywordPageHeader = () => {
     return (
       <Header
@@ -29,10 +32,12 @@ const SelectKeywordPage = () => {
   };
 
   return (
-    <PageLayout renderHeader={renderSelectKeywordPageHeader}>
+    <PageLayout
+      renderHeader={renderSelectKeywordPageHeader}
+      footer={<NextFooter isActiveNext={isActiveNext} navigateURL={'/custom-theme'} />}
+    >
       <SelectKeywordHeading />
-      <SelectKeyword />
-      {/* 나중에 공통에서 가져온 푸터 넣을 예정 */}
+      <SelectKeyword setIsActiveNext={setIsActiveNext} />
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #251 

## 💜 작업 내용
- [x] 라우터 설정 안 해준 거 추가하기
- [x] 디자인 변동사항 반영하기
- [x] 최소 1개 버튼 반영하기

## ✅ PR Point
- 키워드 선택하면 길이가 변경되면서 밀려서 키워드 배치가 달라지는 문제 해결 완료
- 최소 1개의 버튼을 선택해야만 다음 버튼 활성화되도록 수정
- 라우터 설정 반영

## 😡 Trouble Shooting
- 클릭하면 너비가 달라지다 보니 배치가 달라져서 클릭했을 때의 너비를 기준으로 너비값을 수정해줬습니다.
- 자꾸 개발자도구 켜서 실행하면 작동이 제대로 안 됐었는데, 
<img width="129" alt="Screenshot 2023-07-18 at 4 55 51 PM" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/92876819/02a02377-5a89-4a37-a00f-301d8eba4de4">
이 화살표 아이콘을 파란색으로 켜놔야 되는 거였습니다..!

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/92876819/704ece97-9be8-4a3e-bfdf-bd9594e5e958

## Reference
- [개발자도구 paused in debugger 해결방법](https://velog.io/@songjy377/%ED%81%AC%EB%A1%AC-paused-in-debugger-%ED%95%B4%EA%B2%B0%EB%B0%A9%EB%B2%95)
