### PR TITLE
[Custom] custom page navigate 시 state로 필요 한 값 넘기기

### DIFF
--- a/src/common/Footer/NextFooter.tsx
+++ b/src/common/Footer/NextFooter.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
-import { customInfo } from '../../types/customInfoType';
+// import { customInfoType } from '../../types/customInfoType';
 
 interface NextFooterProps {
   isActiveNext?: boolean;

--- a/src/components/Custom/Common/CustomSelectSize.tsx
+++ b/src/components/Custom/Common/CustomSelectSize.tsx
@@ -2,11 +2,12 @@ import { styled } from 'styled-components';
 import CustomSelectSizeBtn from './CustomSelectSizeBtn';
 import { useState, useRef, useEffect } from 'react';
 
-const CustomSelectSize = ({
-  setIsActiveNext,
-}: {
+interface CustomSelectSizeProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
-}) => {
+  setSize: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) => {
   const BTN_DATA = [
     { id: 'quarter', title: '5cm 이하', detail: '동전 크기' },
     { id: 'regular', title: 'A4 1/8', detail: '신용카드, 담뱃갑 크기' },
@@ -21,6 +22,7 @@ const CustomSelectSize = ({
     const target = e.target as HTMLElement;
     if (!target) return;
     setSelectedBtn(target.id);
+    setSize(target.id);
     setIsActiveNext(true);
   };
 

--- a/src/components/Custom/Common/CustomSelectSize.tsx
+++ b/src/components/Custom/Common/CustomSelectSize.tsx
@@ -1,14 +1,14 @@
 import { styled } from 'styled-components';
 import CustomSelectSizeBtn from './CustomSelectSizeBtn';
 import { useState, useRef, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 
 interface CustomSelectSizeProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
   setSize: React.Dispatch<React.SetStateAction<string>>;
+  size: string | null;
 }
 
-const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) => {
+const CustomSelectSize = ({ setIsActiveNext, setSize, size }: CustomSelectSizeProps) => {
   const BTN_DATA = [
     { id: 'quarter', title: '5cm 이하', detail: '동전 크기' },
     { id: 'regular', title: 'A4 1/8', detail: '신용카드, 담뱃갑 크기' },
@@ -16,12 +16,8 @@ const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) =
     { id: 'double', title: '5cm 이하', detail: '아래팔 한 쪽 면 크기' },
   ];
 
-  const location = useLocation();
-  const [selectedBtn, setSelectedBtn] = useState('');
+  const [selectedBtn, setSelectedBtn] = useState(size ? size : '');
   const sizeBtnRef = useRef<HTMLButtonElement[]>([]);
-
-  //state에 있는 size 값 가져오기 (처음 넘어올 때는 customInfo 자체가 없으므로 에러 방지)
-  const size = location.state.customInfo ? location.state.customInfo.size : null;
 
   const handleClickSelBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
     const target = e.target as HTMLElement;

--- a/src/components/Custom/Common/CustomSelectSize.tsx
+++ b/src/components/Custom/Common/CustomSelectSize.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import CustomSelectSizeBtn from './CustomSelectSizeBtn';
 import { useState, useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 interface CustomSelectSizeProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
@@ -15,8 +16,15 @@ const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) =
     { id: 'double', title: '5cm 이하', detail: '아래팔 한 쪽 면 크기' },
   ];
 
+  const location = useLocation();
   const [selectedBtn, setSelectedBtn] = useState('');
   const sizeBtnRef = useRef<HTMLButtonElement[]>([]);
+
+  // console.log(location.state.customInfo.size, '##');
+  const size =
+    location.state && location.state.customInfo.size ? location.state.customInfo.size : null;
+
+  // console.log(size, '???');
 
   const handleClickSelBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
     const target = e.target as HTMLElement;
@@ -36,6 +44,19 @@ const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) =
       }
     });
   }, [selectedBtn]);
+
+  useEffect(() => {
+    if (!size) return;
+    sizeBtnRef.current.forEach((ref) => {
+      if (ref.id === size) {
+        console.log('맞');
+        ref.classList.add('isSelected');
+        setIsActiveNext(true);
+      } else {
+        ref.classList.remove('isSelected');
+      }
+    });
+  }, [size, setIsActiveNext]);
 
   return (
     <St.SizeWrapper>

--- a/src/components/Custom/Common/CustomSelectSize.tsx
+++ b/src/components/Custom/Common/CustomSelectSize.tsx
@@ -20,11 +20,8 @@ const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) =
   const [selectedBtn, setSelectedBtn] = useState('');
   const sizeBtnRef = useRef<HTMLButtonElement[]>([]);
 
-  // console.log(location.state.customInfo.size, '##');
-  const size =
-    location.state && location.state.customInfo.size ? location.state.customInfo.size : null;
-
-  // console.log(size, '???');
+  //state에 있는 size 값 가져오기 (처음 넘어올 때는 customInfo 자체가 없으므로 에러 방지)
+  const size = location.state.customInfo ? location.state.customInfo.size : null;
 
   const handleClickSelBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
     const target = e.target as HTMLElement;
@@ -47,16 +44,17 @@ const CustomSelectSize = ({ setIsActiveNext, setSize }: CustomSelectSizeProps) =
 
   useEffect(() => {
     if (!size) return;
+    //임시저장 + back btn 클릭 시 state에 있는 값 읽어와 반영
     sizeBtnRef.current.forEach((ref) => {
       if (ref.id === size) {
-        console.log('맞');
         ref.classList.add('isSelected');
         setIsActiveNext(true);
+        setSize(ref.id);
       } else {
         ref.classList.remove('isSelected');
       }
     });
-  }, [size, setIsActiveNext]);
+  }, [size, setIsActiveNext, setSize]);
 
   return (
     <St.SizeWrapper>

--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -3,15 +3,16 @@ import { styled } from 'styled-components';
 import CustomImgHeader from './CustomImgHeader';
 import CustomImgAttach from './CustomImgAttach';
 
-const CustomImg = ({
-  setIsActiveNext,
-}: {
+interface CustomImgProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
-}) => {
+  setCustomMainImage: React.Dispatch<React.SetStateAction<File | undefined>>;
+}
+
+const CustomImg = ({ setIsActiveNext, setCustomMainImage }: CustomImgProps) => {
   return (
     <St.CustomImgWrapper>
       <CustomImgHeader />
-      <CustomImgAttach setIsActiveNext={setIsActiveNext} />
+      <CustomImgAttach setIsActiveNext={setIsActiveNext} setCustomMainImage={setCustomMainImage} />
     </St.CustomImgWrapper>
   );
 };

--- a/src/components/Custom/NoDesgin/CustomImg.tsx
+++ b/src/components/Custom/NoDesgin/CustomImg.tsx
@@ -6,13 +6,18 @@ import CustomImgAttach from './CustomImgAttach';
 interface CustomImgProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
   setCustomMainImage: React.Dispatch<React.SetStateAction<File | undefined>>;
+  attachedImg: File | null;
 }
 
-const CustomImg = ({ setIsActiveNext, setCustomMainImage }: CustomImgProps) => {
+const CustomImg = ({ setIsActiveNext, setCustomMainImage, attachedImg }: CustomImgProps) => {
   return (
     <St.CustomImgWrapper>
       <CustomImgHeader />
-      <CustomImgAttach setIsActiveNext={setIsActiveNext} setCustomMainImage={setCustomMainImage} />
+      <CustomImgAttach
+        setIsActiveNext={setIsActiveNext}
+        setCustomMainImage={setCustomMainImage}
+        attachedImg={attachedImg}
+      />
     </St.CustomImgWrapper>
   );
 };

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -2,11 +2,12 @@ import { styled } from 'styled-components';
 import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useEffect, useState } from 'react';
 
-const CustomImgAttach = ({
-  setIsActiveNext,
-}: {
+interface CustomImgAttachProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
-}) => {
+  setCustomMainImage: React.Dispatch<React.SetStateAction<File | undefined>>;
+}
+
+const CustomImgAttach = ({ setIsActiveNext, setCustomMainImage }: CustomImgAttachProps) => {
   const [previewURL, setPreviewURL] = useState('');
 
   useEffect(() => {
@@ -18,6 +19,9 @@ const CustomImgAttach = ({
     if (!files || !files[0]) return; // early return
 
     const fileBlob = files[0]; // 서버 통신 시 보낼 타입
+    setCustomMainImage(fileBlob);
+
+    console.log(fileBlob);
 
     // FileReader로 이미지 미리보기 구현
     const reader = new FileReader();

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 interface CustomImgAttachProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
@@ -8,11 +9,27 @@ interface CustomImgAttachProps {
 }
 
 const CustomImgAttach = ({ setIsActiveNext, setCustomMainImage }: CustomImgAttachProps) => {
+  const location = useLocation();
   const [previewURL, setPreviewURL] = useState('');
+
+  //state에 있는 size 값 가져오기 (처음 넘어올 때는 customInfo 자체가 없으므로 에러 방지)
+  const attachedImg = location.state.customMainImage ? location.state.customMainImage : null;
 
   useEffect(() => {
     previewURL ? setIsActiveNext(true) : setIsActiveNext(false);
   }, [previewURL, setIsActiveNext]);
+
+  useEffect(() => {
+    //state에 있는 attachedImg 값 가져와서 미리보기 구현하기
+    if (!attachedImg) return;
+    setCustomMainImage(attachedImg);
+
+    const reader = new FileReader();
+    reader.readAsDataURL(attachedImg);
+    reader.onloadend = () => {
+      setPreviewURL(reader.result as string);
+    }; // FileReader로 이미지 미리보기 구현
+  }, [attachedImg, setCustomMainImage]);
 
   const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
@@ -23,13 +40,12 @@ const CustomImgAttach = ({ setIsActiveNext, setCustomMainImage }: CustomImgAttac
 
     console.log(fileBlob);
 
-    // FileReader로 이미지 미리보기 구현
     const reader = new FileReader();
     reader.readAsDataURL(fileBlob);
     reader.onloadend = () => {
       setPreviewURL(reader.result as string);
       e.target.value = ''; // 같은 파일을 올리면 change 이벤트 인지 못해서 여기서 초기화
-    };
+    }; // FileReader로 이미지 미리보기 구현
   };
 
   const handleClickImgPreviewDelBtn = () => {

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -38,8 +38,6 @@ const CustomImgAttach = ({
     const fileBlob = files[0]; // 서버 통신 시 보낼 타입
     setCustomMainImage(fileBlob);
 
-    console.log(fileBlob);
-
     const reader = new FileReader();
     reader.readAsDataURL(fileBlob);
     reader.onloadend = () => {

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -12,7 +12,7 @@ const CustomImgAttach = ({ setIsActiveNext, setCustomMainImage }: CustomImgAttac
   const location = useLocation();
   const [previewURL, setPreviewURL] = useState('');
 
-  //state에 있는 size 값 가져오기 (처음 넘어올 때는 customInfo 자체가 없으므로 에러 방지)
+  //state에 있는 img 파일 값 가져오기 (처음 넘어올 때는 customMainImage 값이 없으므로 에러 방지 필요)
   const attachedImg = location.state.customMainImage ? location.state.customMainImage : null;
 
   useEffect(() => {

--- a/src/components/Custom/NoDesgin/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesgin/CustomImgAttach.tsx
@@ -1,19 +1,19 @@
 import { styled } from 'styled-components';
 import { IcCancelDark, IcPhoto } from '../../../assets/icon';
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 
 interface CustomImgAttachProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
   setCustomMainImage: React.Dispatch<React.SetStateAction<File | undefined>>;
+  attachedImg: File | null;
 }
 
-const CustomImgAttach = ({ setIsActiveNext, setCustomMainImage }: CustomImgAttachProps) => {
-  const location = useLocation();
+const CustomImgAttach = ({
+  setIsActiveNext,
+  setCustomMainImage,
+  attachedImg,
+}: CustomImgAttachProps) => {
   const [previewURL, setPreviewURL] = useState('');
-
-  //state에 있는 img 파일 값 가져오기 (처음 넘어올 때는 customMainImage 값이 없으므로 에러 방지 필요)
-  const attachedImg = location.state.customMainImage ? location.state.customMainImage : null;
 
   useEffect(() => {
     previewURL ? setIsActiveNext(true) : setIsActiveNext(false);

--- a/src/components/Custom/NoDesign/CustomRequset.tsx
+++ b/src/components/Custom/NoDesign/CustomRequset.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { styled } from 'styled-components';
 // 이모티콘 카운팅 관련 라이브러리
 import GraphemeSplitter from 'grapheme-splitter';
+import { useLocation } from 'react-router-dom';
 
 interface CustomRequestProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
@@ -12,11 +13,34 @@ interface CustomRequestProps {
 const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestProps) => {
   //count 될 maxCount 수
   const MAX_NAME_COUNT = 10;
-  const MAX_ETC_COUNT = 100;
+  const MAX_DEMAND_COUNT = 100;
+
+  const location = useLocation();
 
   //글자 수 세기 관련 state
   const [nameInputCount, setNameInputCount] = useState(0);
-  const [etcTextAreaCount, setEtcTextAreaCount] = useState(0);
+  const [demandTextAreaCount, setDemandTextAreaCount] = useState(0);
+
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const demandTextAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const writtenName = location.state.customInfo.name ? location.state.customInfo.name : null;
+  const writtenDemand = location.state.customInfo.demand ? location.state.customInfo.demand : null;
+
+  console.log(writtenName, writtenDemand);
+
+  useEffect(() => {
+    if (!writtenName || !nameInputRef.current) return;
+    nameInputRef.current.value = writtenName;
+    setNameInputCount(writtenName.length);
+    setName(writtenName);
+    setIsActiveNext(true);
+
+    if (!writtenDemand || !demandTextAreaRef.current) return;
+    demandTextAreaRef.current.value = writtenDemand;
+    setDemandTextAreaCount(writtenDemand.length);
+    setDemand(writtenDemand);
+  }, [writtenName, writtenDemand]);
 
   // 이모티콘을 한 문자로 취급하여 글자 수 제한을 구현하는 함수
   const limitMaxLength = (
@@ -52,13 +76,13 @@ const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestPro
     setName(e.target.value);
   };
 
-  const handleChangeEtcTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value === '') setEtcTextAreaCount(0);
+  const handleChangeDemandTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value === '') setDemandTextAreaCount(0);
 
-    const lengthCount = limitMaxLength(e, MAX_ETC_COUNT);
+    const lengthCount = limitMaxLength(e, MAX_DEMAND_COUNT);
 
     if (!lengthCount) return;
-    setEtcTextAreaCount(lengthCount);
+    setDemandTextAreaCount(lengthCount);
     setDemand(e.target.value);
   };
 
@@ -73,6 +97,7 @@ const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestPro
             type='text'
             onChange={handleChangeNameInput}
             placeholder='ex. 우리 가족 타투, 백조 타투'
+            ref={nameInputRef}
             autoFocus
           />
           <St.RequestInputCount>
@@ -80,29 +105,30 @@ const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestPro
           </St.RequestInputCount>
         </St.RequestInputBox>
       </St.RequestNameContainer>
-      <St.RequestEtcContainer>
-        <St.RequestEtcTitleBox>
-          <St.RequestEtcTitle>요청 사항</St.RequestEtcTitle>
+      <St.RequestDemandContainer>
+        <St.RequestDemandTitleBox>
+          <St.RequestDemandTitle>요청 사항</St.RequestDemandTitle>
           <St.RequestOptionBadge>선택</St.RequestOptionBadge>
-        </St.RequestEtcTitleBox>
+        </St.RequestDemandTitleBox>
         <div>
-          <St.RequestEtcDetail>
+          <St.RequestDemandDetail>
             추가적인 요청사항이 있다면 자유롭게 작성해주세요
-          </St.RequestEtcDetail>
-          <St.RequestEtcDetail>
+          </St.RequestDemandDetail>
+          <St.RequestDemandDetail>
             (컬러 코드, 정확한 사이즈, 라인 굵기, 명암 여부 등)
-          </St.RequestEtcDetail>
+          </St.RequestDemandDetail>
         </div>
         <St.RequestInputBox>
-          <St.RequestEtcTextArea
-            onChange={handleChangeEtcTextArea}
+          <St.RequestDemandTextArea
+            onChange={handleChangeDemandTextArea}
             placeholder='ex. 라인 1mm로 사진보다 얇게 그려주세요 &#13;&#10; &nbsp; &nbsp;  도안을 붉은색 (FF6B6B)으로 바꿔주세요'
+            ref={demandTextAreaRef}
           />
           <St.RequestInputCount>
-            ({etcTextAreaCount}/{MAX_ETC_COUNT})
+            ({demandTextAreaCount}/{MAX_DEMAND_COUNT})
           </St.RequestInputCount>
         </St.RequestInputBox>
-      </St.RequestEtcContainer>
+      </St.RequestDemandContainer>
     </St.CustomRequestWrapper>
   );
 };
@@ -178,7 +204,7 @@ const St = {
     width: fit-content;
   `,
 
-  RequestEtcContainer: styled.article`
+  RequestDemandContainer: styled.article`
     display: flex;
     flex-direction: column;
     gap: 1.2rem;
@@ -188,29 +214,28 @@ const St = {
     padding: 4rem 2rem 13rem 2.2rem;
   `,
 
-  RequestEtcTitleBox: styled.div`
+  RequestDemandTitleBox: styled.div`
     display: flex;
     align-items: center;
     gap: 0.6rem;
   `,
 
-  RequestEtcTitle: styled.h2`
+  RequestDemandTitle: styled.h2`
     color: ${({ theme }) => theme.colors.gray8};
     ${({ theme }) => theme.fonts.title_semibold_20};
   `,
 
   RequestOptionBadge: styled.span`
     color: ${({ theme }) => theme.colors.pink4};
-    //폰트 추가 필요
     ${({ theme }) => theme.fonts.detail_semibold_12};
   `,
 
-  RequestEtcDetail: styled.p`
+  RequestDemandDetail: styled.p`
     color: ${({ theme }) => theme.colors.gray3};
     ${({ theme }) => theme.fonts.body_medium_14};
   `,
 
-  RequestEtcTextArea: styled.textarea`
+  RequestDemandTextArea: styled.textarea`
     width: 29.5rem;
     height: 14.6rem;
 

--- a/src/components/Custom/NoDesign/CustomRequset.tsx
+++ b/src/components/Custom/NoDesign/CustomRequset.tsx
@@ -3,11 +3,13 @@ import { styled } from 'styled-components';
 // 이모티콘 카운팅 관련 라이브러리
 import GraphemeSplitter from 'grapheme-splitter';
 
-const CustomRequset = ({
-  setIsActiveNext,
-}: {
+interface CustomRequestProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
-}) => {
+  setName: React.Dispatch<React.SetStateAction<string>>;
+  setDemand: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestProps) => {
   //count 될 maxCount 수
   const MAX_NAME_COUNT = 10;
   const MAX_ETC_COUNT = 100;
@@ -47,6 +49,7 @@ const CustomRequset = ({
 
     if (!lengthCount) return;
     setNameInputCount(lengthCount);
+    setName(e.target.value);
   };
 
   const handleChangeEtcTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -56,6 +59,7 @@ const CustomRequset = ({
 
     if (!lengthCount) return;
     setEtcTextAreaCount(lengthCount);
+    setDemand(e.target.value);
   };
 
   return (

--- a/src/components/Custom/NoDesign/CustomRequset.tsx
+++ b/src/components/Custom/NoDesign/CustomRequset.tsx
@@ -29,8 +29,6 @@ const CustomRequset = ({
   const nameInputRef = useRef<HTMLInputElement>(null);
   const demandTextAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  console.log(writtenName, writtenDemand);
-
   useEffect(() => {
     if (!writtenName || !nameInputRef.current) return;
     nameInputRef.current.value = writtenName;

--- a/src/components/Custom/NoDesign/CustomRequset.tsx
+++ b/src/components/Custom/NoDesign/CustomRequset.tsx
@@ -2,20 +2,25 @@ import React, { useEffect, useRef, useState } from 'react';
 import { styled } from 'styled-components';
 // 이모티콘 카운팅 관련 라이브러리
 import GraphemeSplitter from 'grapheme-splitter';
-import { useLocation } from 'react-router-dom';
 
 interface CustomRequestProps {
   setIsActiveNext: React.Dispatch<React.SetStateAction<boolean>>;
   setName: React.Dispatch<React.SetStateAction<string>>;
   setDemand: React.Dispatch<React.SetStateAction<string>>;
+  writtenName: string | null;
+  writtenDemand: string | null;
 }
 
-const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestProps) => {
+const CustomRequset = ({
+  setIsActiveNext,
+  setName,
+  setDemand,
+  writtenName,
+  writtenDemand,
+}: CustomRequestProps) => {
   //count 될 maxCount 수
   const MAX_NAME_COUNT = 10;
   const MAX_DEMAND_COUNT = 100;
-
-  const location = useLocation();
 
   //글자 수 세기 관련 state
   const [nameInputCount, setNameInputCount] = useState(0);
@@ -23,9 +28,6 @@ const CustomRequset = ({ setIsActiveNext, setName, setDemand }: CustomRequestPro
 
   const nameInputRef = useRef<HTMLInputElement>(null);
   const demandTextAreaRef = useRef<HTMLTextAreaElement>(null);
-
-  const writtenName = location.state.customInfo.name ? location.state.customInfo.name : null;
-  const writtenDemand = location.state.customInfo.demand ? location.state.customInfo.demand : null;
 
   console.log(writtenName, writtenDemand);
 

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -22,6 +22,8 @@ const CustomSizePage = () => {
 
   const haveDesign = location.state ? location.state.haveDesign : null;
   const customId = location.state ? location.state.customId : null;
+  const customMainImage = location.state ? location.state.customMainImage : null;
+  const customImages = location.state ? location.state.customImages : null;
   const navigateURL = haveDesign ? '/custom-reference' : '/custom-img';
 
   useEffect(() => {
@@ -59,6 +61,8 @@ const CustomSizePage = () => {
           navigateURL={navigateURL}
           haveDesign={haveDesign}
           customInfo={customInfo}
+          customMainImage={customMainImage}
+          customImages={customImages}
         />
       }
     >

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -23,6 +23,8 @@ const CustomSizePage = () => {
   const haveDesign = location.state ? location.state.haveDesign : null;
   const customId = location.state ? location.state.customId : null;
 
+  console.log('size', location.state);
+
   const customInfo: customInfo = {
     viewCount: CUSTOM_VIEW_COUNT,
     customId: customId,

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -26,7 +26,8 @@ const CustomSizePage = () => {
   const customImages = location.state ? location.state.customImages : null;
   const navigateURL = haveDesign ? '/custom-reference' : '/custom-img';
 
-  const sizeState = location.state.customInfo ? location.state.customInfo.size : null;
+  const sizeState =
+    location.state && location.state.customInfo ? location.state.customInfo.size : null;
 
   useEffect(() => {
     if (!location.state) navigate('/onboarding');

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -7,10 +7,24 @@ import PageLayout from '../../../components/PageLayout';
 import NextFooter from '../../../common/Footer/NextFooter';
 import { useState } from 'react';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
+import { useLocation } from 'react-router-dom';
+import { customInfo } from '../../../types/customInfo';
 
 const CustomSizePage = () => {
+  const CUSTOM_VIEW_COUNT = 1;
+
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
+  const [size, setSize] = useState('');
+
+  const location = useLocation();
+  const { haveDesign, customId } = location.state;
+
+  const customInfo: customInfo = {
+    viewCount: CUSTOM_VIEW_COUNT,
+    customId: customId,
+    size: size,
+  };
 
   const renderCustomSizePageHeader = () => {
     return (
@@ -31,9 +45,16 @@ const CustomSizePage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomSizePageHeader}
-      footer={<NextFooter isActiveNext={isActiveNext} navigateURL='/custom-img' />}
+      footer={
+        <NextFooter
+          isActiveNext={isActiveNext}
+          navigateURL='/custom-img'
+          haveDesign={haveDesign}
+          customInfo={customInfo}
+        />
+      }
     >
-      <CustomSelectSize setIsActiveNext={setIsActiveNext} />
+      <CustomSelectSize setIsActiveNext={setIsActiveNext} setSize={setSize} />
     </PageLayout>
   );
 };

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -26,6 +26,8 @@ const CustomSizePage = () => {
   const customImages = location.state ? location.state.customImages : null;
   const navigateURL = haveDesign ? '/custom-reference' : '/custom-img';
 
+  const sizeState = location.state.customInfo ? location.state.customInfo.size : null;
+
   useEffect(() => {
     if (!location.state) navigate('/onboarding');
   }, [location.state, navigate]);
@@ -66,7 +68,7 @@ const CustomSizePage = () => {
         />
       }
     >
-      <CustomSelectSize setIsActiveNext={setIsActiveNext} setSize={setSize} />
+      <CustomSelectSize setIsActiveNext={setIsActiveNext} setSize={setSize} size={sizeState} />
     </PageLayout>
   );
 };

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -15,10 +15,13 @@ const CustomSizePage = () => {
 
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
+
   const [size, setSize] = useState('');
 
   const location = useLocation();
-  const { haveDesign, customId } = location.state;
+
+  const haveDesign = location.state ? location.state.haveDesign : null;
+  const customId = location.state ? location.state.customId : null;
 
   const customInfo: customInfo = {
     viewCount: CUSTOM_VIEW_COUNT,

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -8,7 +8,6 @@ import NextFooter from '../../../common/Footer/NextFooter';
 import { useState } from 'react';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
 import { useLocation } from 'react-router-dom';
-import { customInfo } from '../../../types/customInfo';
 
 const CustomSizePage = () => {
   const CUSTOM_VIEW_COUNT = 1;
@@ -22,10 +21,11 @@ const CustomSizePage = () => {
 
   const haveDesign = location.state ? location.state.haveDesign : null;
   const customId = location.state ? location.state.customId : null;
+  const navigateURL = haveDesign ? '/custom-reference' : '/custom-img';
 
   console.log('size', location.state);
 
-  const customInfo: customInfo = {
+  const customInfo = {
     viewCount: CUSTOM_VIEW_COUNT,
     customId: customId,
     size: size,
@@ -53,7 +53,7 @@ const CustomSizePage = () => {
       footer={
         <NextFooter
           isActiveNext={isActiveNext}
-          navigateURL='/custom-img'
+          navigateURL={navigateURL}
           haveDesign={haveDesign}
           customInfo={customInfo}
         />

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -5,9 +5,9 @@ import CancelBtn from '../../../common/Header/CancelBtn';
 import ProgressBar from '../../../common/ProgressBar';
 import PageLayout from '../../../components/PageLayout';
 import NextFooter from '../../../common/Footer/NextFooter';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const CustomSizePage = () => {
   const CUSTOM_VIEW_COUNT = 1;
@@ -17,11 +17,16 @@ const CustomSizePage = () => {
 
   const [size, setSize] = useState('');
 
+  const navigate = useNavigate();
   const location = useLocation();
 
   const haveDesign = location.state ? location.state.haveDesign : null;
   const customId = location.state ? location.state.customId : null;
   const navigateURL = haveDesign ? '/custom-reference' : '/custom-img';
+
+  useEffect(() => {
+    if (!location.state) navigate('/onboarding');
+  }, [location.state, navigate]);
 
   console.log('size', location.state);
 

--- a/src/page/Custom/Common/CustomSizePage.tsx
+++ b/src/page/Custom/Common/CustomSizePage.tsx
@@ -28,8 +28,6 @@ const CustomSizePage = () => {
     if (!location.state) navigate('/onboarding');
   }, [location.state, navigate]);
 
-  console.log('size', location.state);
-
   const customInfo = {
     viewCount: CUSTOM_VIEW_COUNT,
     customId: customId,

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -18,14 +18,15 @@ const CustomImgPage = () => {
   const [customMainImage, setCustomMainImage] = useState<File>();
   const location = useLocation();
 
-  const { haveDesign, customInfo: prevCustomInfo } = location.state;
+  const haveDesign = location.state ? location.state.haveDesgin : null;
+  const prevCustomInfo = location.state ? location.state.customInfo : null;
 
   const customInfo = {
     ...prevCustomInfo,
     viewCount: CUSTOM_VIEW_COUNT,
   };
 
-  console.log(location.state, '!!!');
+  console.log('img', location.state);
 
   const renderCustomImgPageHeader = () => {
     return (
@@ -34,7 +35,7 @@ const CustomImgPage = () => {
           <IcBackDark
             onClick={() =>
               navigate('/custom-size', {
-                state: location.state,
+                state: location.state ? location.state : null,
               })
             }
           />

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -10,17 +10,35 @@ import { IcBackDark } from '../../../assets/icon';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const CustomImgPage = () => {
+  const CUSTOM_VIEW_COUNT = 2;
+
   const navigate = useNavigate();
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
+  const [customMainImage, setCustomMainImage] = useState<File>();
   const location = useLocation();
+
+  const { haveDesign, customInfo: prevCustomInfo } = location.state;
+
+  const customInfo = {
+    ...prevCustomInfo,
+    viewCount: CUSTOM_VIEW_COUNT,
+  };
 
   console.log(location.state, '!!!');
 
   const renderCustomImgPageHeader = () => {
     return (
       <Header
-        leftSection={<IcBackDark onClick={() => navigate('/custom-size')} />}
+        leftSection={
+          <IcBackDark
+            onClick={() =>
+              navigate('/custom-size', {
+                state: location.state,
+              })
+            }
+          />
+        }
         title='커스텀 타투'
         rightSection={
           <CancelBtn
@@ -37,9 +55,17 @@ const CustomImgPage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomImgPageHeader}
-      footer={<NextFooter isActiveNext={isActiveNext} navigateURL='/custom-request' />}
+      footer={
+        <NextFooter
+          isActiveNext={isActiveNext}
+          navigateURL='/custom-request'
+          haveDesign={haveDesign}
+          customInfo={customInfo}
+          customMainImage={customMainImage}
+        />
+      }
     >
-      <CustomImg setIsActiveNext={setIsActiveNext} />
+      <CustomImg setIsActiveNext={setIsActiveNext} setCustomMainImage={setCustomMainImage} />
     </PageLayout>
   );
 };

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CustomImg from '../../../components/Custom/NoDesgin/CustomImg';
 import Header from '../../../components/Header';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
@@ -20,6 +20,10 @@ const CustomImgPage = () => {
 
   const haveDesign = location.state ? location.state.haveDesgin : null;
   const prevCustomInfo = location.state ? location.state.customInfo : null;
+
+  useEffect(() => {
+    if (!location.state) navigate('/onboarding');
+  }, [location.state, navigate]);
 
   const customInfo = {
     ...prevCustomInfo,

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -14,7 +14,8 @@ const CustomImgPage = () => {
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
   const location = useLocation();
-  const stateList = location.state;
+
+  console.log(location.state, '!!!');
 
   const renderCustomImgPageHeader = () => {
     return (
@@ -36,13 +37,7 @@ const CustomImgPage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomImgPageHeader}
-      footer={
-        <NextFooter
-          isActiveNext={isActiveNext}
-          navigateURL='/custom-request'
-          stateList={stateList}
-        />
-      }
+      footer={<NextFooter isActiveNext={isActiveNext} navigateURL='/custom-request' />}
     >
       <CustomImg setIsActiveNext={setIsActiveNext} />
     </PageLayout>

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -30,8 +30,6 @@ const CustomImgPage = () => {
     viewCount: CUSTOM_VIEW_COUNT,
   };
 
-  console.log('img', location.state);
-
   const renderCustomImgPageHeader = () => {
     return (
       <Header

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -21,6 +21,10 @@ const CustomImgPage = () => {
   const haveDesign = location.state ? location.state.haveDesgin : null;
   const prevCustomInfo = location.state ? location.state.customInfo : null;
 
+  //state에 있는 img 파일 값 가져오기 (처음 넘어올 때는 customMainImage 값이 없으므로 에러 방지 필요)
+  const attachedImg =
+    location.state && location.state.customMainImage ? location.state.customMainImage : null;
+
   useEffect(() => {
     if (!location.state) navigate('/onboarding');
   }, [location.state, navigate]);
@@ -68,7 +72,11 @@ const CustomImgPage = () => {
         />
       }
     >
-      <CustomImg setIsActiveNext={setIsActiveNext} setCustomMainImage={setCustomMainImage} />
+      <CustomImg
+        setIsActiveNext={setIsActiveNext}
+        setCustomMainImage={setCustomMainImage}
+        attachedImg={attachedImg}
+      />
     </PageLayout>
   );
 };

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -35,11 +35,11 @@ const CustomImgPage = () => {
       <Header
         leftSection={
           <IcBackDark
-            onClick={() =>
+            onClick={() => {
               navigate('/custom-size', {
                 state: location.state ? location.state : null,
-              })
-            }
+              });
+            }}
           />
         }
         title='커스텀 타투'

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -10,17 +10,38 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { IcBackDark } from '../../../assets/icon';
 
 const CustomRequestPage = () => {
+  const CUSTOM_VIEW_COUNT = 3;
+
   const navigate = useNavigate();
   const location = useLocation();
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
+  const [name, setName] = useState('');
+  const [demand, setDemand] = useState('');
+
+  const { haveDesign, customInfo: prevCustomInfo, customMainImage } = location.state;
+
+  const customInfo = {
+    ...prevCustomInfo,
+    viewCount: CUSTOM_VIEW_COUNT,
+    name: name,
+    demand: demand,
+  };
 
   console.log(location.state);
 
   const renderCustomRequestPageHeader = () => {
     return (
       <Header
-        leftSection={<IcBackDark onClick={() => navigate('/custom-img')} />}
+        leftSection={
+          <IcBackDark
+            onClick={() =>
+              navigate('/custom-img', {
+                state: location.state,
+              })
+            }
+          />
+        }
         title='커스텀 타투'
         rightSection={
           <CancelBtn
@@ -36,9 +57,17 @@ const CustomRequestPage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomRequestPageHeader}
-      footer={<NextFooter isActiveNext={isActiveNext} navigateURL='/custom-quantity' />}
+      footer={
+        <NextFooter
+          isActiveNext={isActiveNext}
+          navigateURL='/price'
+          haveDesign={haveDesign}
+          customInfo={customInfo}
+          customMainImage={customMainImage}
+        />
+      }
     >
-      <CustomRequset setIsActiveNext={setIsActiveNext} />
+      <CustomRequset setIsActiveNext={setIsActiveNext} setName={setName} setDemand={setDemand} />
     </PageLayout>
   );
 };

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -23,6 +23,12 @@ const CustomRequestPage = () => {
   const prevCustomInfo = location.state ? location.state.customInfo : null;
   const customMainImage = location.state ? location.state.customMainImage : null;
 
+  //state에 있는 name, demand 값 가져오기 (처음 넘어올 때는 customMainImage 값이 없으므로 에러 방지 필요)
+  const writtenName =
+    location.state && location.state.customInfo.name ? location.state.customInfo.name : null;
+  const writtenDemand =
+    location.state && location.state.customInfo.demand ? location.state.customInfo.demand : null;
+
   useEffect(() => {
     if (!location.state) navigate('/onboarding');
   }, [location.state, navigate]);
@@ -73,7 +79,13 @@ const CustomRequestPage = () => {
         />
       }
     >
-      <CustomRequset setIsActiveNext={setIsActiveNext} setName={setName} setDemand={setDemand} />
+      <CustomRequset
+        setIsActiveNext={setIsActiveNext}
+        setName={setName}
+        setDemand={setDemand}
+        writtenName={writtenName}
+        writtenDemand={writtenDemand}
+      />
     </PageLayout>
   );
 };

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -27,6 +27,8 @@ const CustomRequestPage = () => {
     if (!location.state) navigate('/onboarding');
   }, [location.state, navigate]);
 
+  console.log(location.state);
+
   const customInfo = {
     ...prevCustomInfo,
     viewCount: CUSTOM_VIEW_COUNT,

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -19,7 +19,9 @@ const CustomRequestPage = () => {
   const [name, setName] = useState('');
   const [demand, setDemand] = useState('');
 
-  const { haveDesign, customInfo: prevCustomInfo, customMainImage } = location.state;
+  const haveDesign = location.state ? location.state.haveDesign : null;
+  const prevCustomInfo = location.state ? location.state.customInfo : null;
+  const customMainImage = location.state ? location.state.customMainImage : null;
 
   const customInfo = {
     ...prevCustomInfo,
@@ -28,8 +30,6 @@ const CustomRequestPage = () => {
     demand: demand,
   };
 
-  console.log(location.state);
-
   const renderCustomRequestPageHeader = () => {
     return (
       <Header
@@ -37,7 +37,7 @@ const CustomRequestPage = () => {
           <IcBackDark
             onClick={() =>
               navigate('/custom-img', {
-                state: location.state,
+                state: location.state ? location.state : null,
               })
             }
           />

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -33,8 +33,6 @@ const CustomRequestPage = () => {
     if (!location.state) navigate('/onboarding');
   }, [location.state, navigate]);
 
-  console.log(location.state);
-
   const customInfo = {
     ...prevCustomInfo,
     viewCount: CUSTOM_VIEW_COUNT,

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -15,7 +15,7 @@ const CustomRequestPage = () => {
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
 
-  const stateList = location.state;
+  console.log(location.state);
 
   const renderCustomRequestPageHeader = () => {
     return (
@@ -36,13 +36,7 @@ const CustomRequestPage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomRequestPageHeader}
-      footer={
-        <NextFooter
-          isActiveNext={isActiveNext}
-          navigateURL='/custom-quantity'
-          stateList={stateList}
-        />
-      }
+      footer={<NextFooter isActiveNext={isActiveNext} navigateURL='/custom-quantity' />}
     >
       <CustomRequset setIsActiveNext={setIsActiveNext} />
     </PageLayout>

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CancelBtn from '../../../common/Header/CancelBtn';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
 import ProgressBar from '../../../common/ProgressBar';
@@ -22,6 +22,10 @@ const CustomRequestPage = () => {
   const haveDesign = location.state ? location.state.haveDesign : null;
   const prevCustomInfo = location.state ? location.state.customInfo : null;
   const customMainImage = location.state ? location.state.customMainImage : null;
+
+  useEffect(() => {
+    if (!location.state) navigate('/onboarding');
+  }, [location.state, navigate]);
 
   const customInfo = {
     ...prevCustomInfo,

--- a/src/page/Custom/PricePage.tsx
+++ b/src/page/Custom/PricePage.tsx
@@ -42,7 +42,7 @@ const PricePage = () => {
           <IcBackDark
             onClick={() =>
               navigate(backNavigateURL, {
-                state: location.state,
+                state: location.state ? location.state : null,
               })
             }
           />

--- a/src/page/Custom/PricePage.tsx
+++ b/src/page/Custom/PricePage.tsx
@@ -19,7 +19,11 @@ const PricePage = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { haveDesign, customInfo: prevCustomInfo, customMainImage, customImages } = location.state;
+  const haveDesign = location.state ? location.state.haveDesign : null;
+  const prevCustomInfo = location.state ? location.state.customInfo : null;
+  const customMainImage = location.state ? location.state.customInfo : null;
+
+  // const { haveDesign, customInfo: prevCustomInfo, customMainImage, customImages } = location.state; //가져와야 할 값들 -> 확인 후 지워주세요!
 
   const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
   const backNavigateURL = haveDesign ? '/additional-request' : '/custom-request';
@@ -28,6 +32,8 @@ const PricePage = () => {
     ...prevCustomInfo,
     viewCount: CUSTOM_VIEW_COUNT,
   };
+
+  console.log(customInfo, customMainImage); //오류 발생 방지 용 console 나중에 footer로 넘겨주고 지워주세요!
 
   const renderPricePageHeader = () => {
     return (

--- a/src/page/Custom/PricePage.tsx
+++ b/src/page/Custom/PricePage.tsx
@@ -9,7 +9,7 @@ import PriceFooter from '../../components/Custom/PriceFooter';
 import MakePublic from '../../components/Custom/MakePublic';
 import CustomSizeEscapeModal from '../../common/Modal/EscapeModal/CustomSizeEscapeModal';
 import { styled } from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { IcBackDark } from '../../assets/icon';
 
 const PricePage = () => {
@@ -17,11 +17,30 @@ const PricePage = () => {
   const [isPublic, setIsPublic] = useState(false);
 
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const { haveDesign, customInfo: prevCustomInfo, customMainImage, customImages } = location.state;
+
+  const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
+  const backNavigateURL = haveDesign ? '/additional-request' : '/custom-request';
+
+  const customInfo = {
+    ...prevCustomInfo,
+    viewCount: CUSTOM_VIEW_COUNT,
+  };
 
   const renderPricePageHeader = () => {
     return (
       <Header
-        leftSection={<IcBackDark onClick={() => navigate('/additional-request')} />}
+        leftSection={
+          <IcBackDark
+            onClick={() =>
+              navigate(backNavigateURL, {
+                state: location.state,
+              })
+            }
+          />
+        }
         title='커스텀 타투'
         rightSection={
           <CancelBtn
@@ -31,7 +50,7 @@ const PricePage = () => {
           />
         }
         transparent={true}
-        progressBar={<ProgressBar curStep={7} maxStep={7} />}
+        progressBar={<ProgressBar curStep={CUSTOM_VIEW_COUNT} maxStep={CUSTOM_VIEW_COUNT} />}
       />
     );
   };

--- a/src/page/Custom/PricePage.tsx
+++ b/src/page/Custom/PricePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CancelBtn from '../../common/Header/CancelBtn';
 import ProgressBar from '../../common/ProgressBar';
 import CountPrice from '../../components/Custom/CountPrice';
@@ -27,6 +27,10 @@ const PricePage = () => {
 
   const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
   const backNavigateURL = haveDesign ? '/additional-request' : '/custom-request';
+
+  useEffect(() => {
+    if (!location.state) navigate('/onboarding');
+  }, [location.state, navigate]);
 
   const customInfo = {
     ...prevCustomInfo,


### PR DESCRIPTION
## 🔥 Related Issues
resolved #347

## 💜 작업 내용
- [x] custom page navigate 시 state로 haveDesign, customInfo, MainImage 등 필요한 값 넘기기 구현 (select ~ 이미 그려둔 도안이 있는 경우 페이지만 구현 + Price 는 필수 값만 구현, 추후 지민 언니가 추가 필요!)
- [x] haveDesign state 값 없이 접근한 경우 -> 커스텀 신청서 플로우대로가 아닌 url을 타고 들어온 경우이므로 디팀이랑 상의해서 onboarding으로 navigate 시키도록 구현
- [x] state 값이 없는 경우 (처음 커스텀 신청 플로우를 따른 경우) 에러 발생 -> 삼항연산자 조건문을 다 걸어줘서 Null 값을 읽어오는 상황에 대한 에러 해결

## ✅ PR Point
- 다음 페이지로 navigate 시 state 넘기기
```ts
//CustomImgPage 예시
...

  const haveDesign = location.state ? location.state.haveDesgin : null;
  const prevCustomInfo = location.state ? location.state.customInfo : null;

//state에서 필요 값 가져오고


...

  const customInfo = {
    ...prevCustomInfo,
    viewCount: CUSTOM_VIEW_COUNT,
  };

//해당 페이지에서 가져와서 넘겨줘야 하는 값을 스프레드 문법으로 update

...

```

* 신청서 플로우대로가 아닌 url로 접근하여 중간 페이지에서 haveDesign(상황 선택)에 대한 값이 없는 경우 onboarding으로 navigate
```ts
  useEffect(() => {
    if (!location.state) navigate('/onboarding');
  }, [location.state, navigate]);

//useEffect로 확인 후 navigate

```


## 😡 Trouble Shooting
- 에러 핸들링이 어려웠습니다 플로우가 복잡해 예기치 않은 상황이 많이 발생하는듯 합니다
- 아직 state에 있는 값을 읽어와 화면에 뿌려오는건 구현 중입니다 해당 pr에 추가로 커밋하겠습니다

## ☀️ 스크린샷 / GIF / 화면 녹화 

