### PR TITLE
[LoginPage] 페이지 병합 2차 리팩토링

### DIFF
--- a/src/common/Header/BackBtn.tsx
+++ b/src/common/Header/BackBtn.tsx
@@ -3,7 +3,7 @@ import { IcBackDark } from '../../assets/icon';
 import { useNavigate } from 'react-router-dom';
 
 interface BackBtnProps {
-  step: number;
+  step?: number;
   setStep: React.Dispatch<SetStateAction<number>>;
 }
 
@@ -11,7 +11,7 @@ const BackBtn = ({ step, setStep }: BackBtnProps) => {
   const navigate = useNavigate();
 
   const handleClickBack = () => {
-    step === 0 ? navigate('/') : setStep(step - 1);
+    step === 0 ? navigate('/') : setStep((prev) => prev - 1);
   };
 
   return <IcBackDark onClick={handleClickBack} />;

--- a/src/common/Header/BackBtn.tsx
+++ b/src/common/Header/BackBtn.tsx
@@ -4,14 +4,14 @@ import { useNavigate } from 'react-router-dom';
 
 interface BackBtnProps {
   step?: number;
-  setStep: React.Dispatch<SetStateAction<number>>;
+  setStep?: React.Dispatch<SetStateAction<number>>;
 }
 
 const BackBtn = ({ step, setStep }: BackBtnProps) => {
   const navigate = useNavigate();
 
   const handleClickBack = () => {
-    step === 0 ? navigate('/') : setStep((prev) => prev - 1);
+    step && setStep ? setStep(step - 1) : navigate(-1);
   };
 
   return <IcBackDark onClick={handleClickBack} />;

--- a/src/common/Header/BackBtn.tsx
+++ b/src/common/Header/BackBtn.tsx
@@ -1,11 +1,17 @@
+import { SetStateAction } from 'react';
 import { IcBackDark } from '../../assets/icon';
 import { useNavigate } from 'react-router-dom';
 
-const BackBtn = () => {
+interface BackBtnProps {
+  step: number;
+  setStep: React.Dispatch<SetStateAction<number>>;
+}
+
+const BackBtn = ({ step, setStep }: BackBtnProps) => {
   const navigate = useNavigate();
 
   const handleClickBack = () => {
-    navigate(-1);
+    step === 0 ? navigate('/') : setStep(step - 1);
   };
 
   return <IcBackDark onClick={handleClickBack} />;

--- a/src/common/Modal/EscapeModal/EscapeModalForm.tsx
+++ b/src/common/Modal/EscapeModal/EscapeModalForm.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { IcCancelDark } from '../../../assets/icon';
 import { useNavigate } from 'react-router-dom';
+import { removeAccessToken } from '../../../libs/api';
 
 interface EscapeModalFormProps {
   redirectURL?: string;
@@ -22,15 +23,14 @@ const EscapeModalForm = ({
   stopBtn,
 }: EscapeModalFormProps) => {
   const navigate = useNavigate();
-  // const location = useLocation();
-  // const patchStates = location.state;
 
   const handleClickStopBtn = () => {
     onClose();
     switch (pageName) {
       // 페이지 이름과 라우팅 주소는 나중에 보고 수정
       case 'LoginPage':
-        navigate('/login');
+        navigate('/');
+        removeAccessToken();
         break;
 
       case 'ChargePage':

--- a/src/components/Register/RegisterNameFooter.tsx
+++ b/src/components/Register/RegisterNameFooter.tsx
@@ -1,16 +1,19 @@
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { SetStateAction } from 'react';
 
 interface RegisterNameFooterProps {
   userName: string;
+  setStep: React.Dispatch<SetStateAction<number>>;
 }
 
-const RegisterNameFooter = ({ userName }: RegisterNameFooterProps) => {
+const RegisterNameFooter = ({ userName, setStep }: RegisterNameFooterProps) => {
   const navigate = useNavigate();
 
   const handleClickFooter = () => {
     if (userName) {
-      navigate('/login', { state: { userName: userName, step: 2 } });
+      navigate('/login', { state: { userName: userName } });
+      setStep(2);
     }
   };
 

--- a/src/components/Register/RegisterPhoneNum.tsx
+++ b/src/components/Register/RegisterPhoneNum.tsx
@@ -2,13 +2,17 @@ import styled from 'styled-components';
 import TitleForm from './RegisterTitleForm';
 import { TITLE, SUB_TITLE } from '../../constants/TitleInfo';
 import RegisterPhoneNumForm from './RegisterPhoneNumForm';
+import { SetStateAction } from 'react';
 
-const RegisterPhoneNum = () => {
+interface RegisterPhoneNumProps {
+  setStep: React.Dispatch<SetStateAction<number>>;
+}
 
+const RegisterPhoneNum = ({ setStep }: RegisterPhoneNumProps) => {
   return (
     <St.RegisterPhoneNumWrapper>
       <TitleForm title={TITLE[1]} subTitle={SUB_TITLE[1]} />
-      <RegisterPhoneNumForm />
+      <RegisterPhoneNumForm setStep={setStep} />
     </St.RegisterPhoneNumWrapper>
   );
 };

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -1,12 +1,16 @@
 import { styled } from 'styled-components';
 import sliceMaxLength from '../../utils/sliceMaxLength';
-import React, { useState } from 'react';
+import React, { SetStateAction, useState } from 'react';
 import Toast from '../../common/ToastMessage/Toast';
 import Timer from './Timer';
 import ErrorMessage from './ErrorMessage';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
+
+interface RegisterPhoneNumFormProps {
+  setStep: React.Dispatch<SetStateAction<number>>;
+}
 
 interface resProps {
   data: {
@@ -20,7 +24,7 @@ interface usePatchProfileProps {
   phoneNum: string;
 }
 
-const RegisterPhoneNumForm = ({setStep}: RegisterPhoneNumProps) => {
+const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
 
   const navigate = useNavigate();

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -7,7 +7,6 @@ import ErrorMessage from './ErrorMessage';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
-import { RegisterPhoneNumProps } from './RegisterPhoneNum';
 
 interface resProps {
   data: {

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -7,6 +7,7 @@ import ErrorMessage from './ErrorMessage';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
+import { RegisterPhoneNumProps } from './RegisterPhoneNum';
 
 interface resProps {
   data: {
@@ -20,7 +21,7 @@ interface usePatchProfileProps {
   phoneNum: string;
 }
 
-const RegisterPhoneNumForm = () => {
+const RegisterPhoneNumForm = ({setStep}: RegisterPhoneNumProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
 
   const navigate = useNavigate();
@@ -55,7 +56,8 @@ const RegisterPhoneNumForm = () => {
         {},
       )
       .then(() => {
-        navigate('/login', { state: { step: 3 } });
+        navigate('/login');
+        setStep(3);
       })
       .catch((Error: object) => {
         console.log(Error);

--- a/src/page/Login/LoginPage.tsx
+++ b/src/page/Login/LoginPage.tsx
@@ -21,7 +21,7 @@ const LoginPage = () => {
   const [modalOn, setModalOn] = useState(false);
   const navigate = useNavigate();
   const { state } = useLocation();
-  const step = state?.step || 0;
+  const [step, setStep] = useState(state?.step ? state.step : 0);
 
   const renderLoginPageHeader = () => {
     return <Header transparent={true} leftSection={<BackBtn />} fixed={true} />;
@@ -32,7 +32,14 @@ const LoginPage = () => {
       <Header
         leftSection={<St.BlankSection></St.BlankSection>}
         title='회원가입'
-        rightSection={<IcCancelDark onClick={() => navigate('/login')} />}
+        rightSection={
+          <IcCancelDark
+            onClick={() => {
+              navigate('/login');
+              setStep(0);
+            }}
+          />
+        }
         progressBar={<ProgressBar curStep={1} maxStep={3} />}
       />
     );
@@ -98,7 +105,10 @@ const LoginPage = () => {
 
     case 1:
       return (
-        <PageLayout renderHeader={renderHeader} footer={<RegisterNameFooter userName={userName} />}>
+        <PageLayout
+          renderHeader={renderHeader}
+          footer={<RegisterNameFooter userName={userName} setStep={setStep} />}
+        >
           <RegisterName setUserName={setUserName} />
         </PageLayout>
       );
@@ -106,7 +116,7 @@ const LoginPage = () => {
     case 2:
       return (
         <PageLayout renderHeader={renderHeader}>
-          <RegisterPhoneNum />
+          <RegisterPhoneNum setStep={setStep} />
         </PageLayout>
       );
 

--- a/src/page/Login/LoginPage.tsx
+++ b/src/page/Login/LoginPage.tsx
@@ -23,7 +23,6 @@ const LoginPage = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const [step, setStep] = useState(state?.step ? state.step : 0);
-  const ACCESS_TOKEN_KEY = 'accesstoken';
 
   const renderLoginPageHeader = () => {
     return (
@@ -33,7 +32,7 @@ const LoginPage = () => {
           <IcBackDark
             onClick={() => {
               navigate('/');
-              removeAccessToken(ACCESS_TOKEN_KEY);
+              removeAccessToken();
             }}
           />
         }

--- a/src/page/Login/LoginPage.tsx
+++ b/src/page/Login/LoginPage.tsx
@@ -129,42 +129,14 @@ const LoginPage = () => {
     }
   }
 
-  // 어떤 컴포넌트를 렌더할지 결정하는 함수
-  switch (step) {
-    case 0:
-      return (
-        <PageLayout renderHeader={renderHeader} footer={<LoginFooter />}>
-          <LoginHome />
-        </PageLayout>
-      );
-
-    case 1:
-      return (
-        <PageLayout
-          renderHeader={renderHeader}
-          footer={<RegisterNameFooter userName={userName} setStep={setStep} />}
-        >
-          <RegisterName setUserName={setUserName} />
-        </PageLayout>
-      );
-
-    case 2:
-      return (
-        <PageLayout renderHeader={renderHeader}>
-          <RegisterPhoneNum setStep={setStep} />
-        </PageLayout>
-      );
-
-    case 3:
-      return (
-        <PageLayout renderHeader={renderHeader} footer={<WelcomeFooter />}>
-          <WelcomeHome />
-        </PageLayout>
-      );
-
-    default:
-      break;
-  }
+  return (
+    <PageLayout renderHeader={renderHeader} footer={renderFooter()}>
+      {step === 0 && <LoginHome />}
+      {step === 1 && <RegisterName setUserName={setUserName} />}
+      {step === 2 && <RegisterPhoneNum setStep={setStep} />}
+      {step === 3 && <WelcomeHome />}
+    </PageLayout>
+  );
 };
 
 const St = {

--- a/src/page/Login/LoginPage.tsx
+++ b/src/page/Login/LoginPage.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   const [step, setStep] = useState(state?.step ? state.step : 0);
 
   const renderLoginPageHeader = () => {
-    return <Header transparent={true} leftSection={<BackBtn />} fixed={true} />;
+    return <Header transparent={true} leftSection={<BackBtn step={step} setStep={setStep}/>} fixed={true} />;
   };
 
   const renderRegisterNamePageHeader = () => {
@@ -48,7 +48,7 @@ const LoginPage = () => {
   const renderRegisterPhoneNumPageHeader = () => {
     return (
       <Header
-        leftSection={<BackBtn />}
+        leftSection={<BackBtn step={step} setStep={setStep} />}
         title='회원가입'
         rightSection={
           <CancelBtn

--- a/src/page/Login/LoginPage.tsx
+++ b/src/page/Login/LoginPage.tsx
@@ -108,6 +108,27 @@ const LoginPage = () => {
     }
   };
 
+  // 어떤 푸터를 렌더할지 결정하는 함수
+  const renderFooter = () => {
+    switch (step) {
+      case 0:
+        return <LoginFooter />;
+        
+
+      case 1:
+        return <RegisterNameFooter userName={userName} setStep={setStep} />;
+
+      case 2:
+        return <></>;
+
+      case 3:
+        return <WelcomeFooter />;
+
+      default:
+        return <></>;
+    }
+  }
+
   // 어떤 컴포넌트를 렌더할지 결정하는 함수
   switch (step) {
     case 0:

--- a/src/page/Login/LoginPage.tsx
+++ b/src/page/Login/LoginPage.tsx
@@ -14,7 +14,8 @@ import RegisterPhoneNum from '../../components/Register/RegisterPhoneNum';
 import WelcomeHome from '../../components/Welcome/WelcomeHome';
 import WelcomeFooter from '../../components/Welcome/WelcomeFooter';
 import LoginEscapeModal from '../../common/Modal/EscapeModal/LoginEscapeModal';
-import { IcCancelDark } from '../../assets/icon';
+import { IcBackDark, IcCancelDark } from '../../assets/icon';
+import { removeAccessToken } from '../../libs/api';
 
 const LoginPage = () => {
   const [userName, setUserName] = useState('');
@@ -22,9 +23,23 @@ const LoginPage = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const [step, setStep] = useState(state?.step ? state.step : 0);
+  const ACCESS_TOKEN_KEY = 'accesstoken';
 
   const renderLoginPageHeader = () => {
-    return <Header transparent={true} leftSection={<BackBtn step={step} setStep={setStep}/>} fixed={true} />;
+    return (
+      <Header
+        transparent={true}
+        leftSection={
+          <IcBackDark
+            onClick={() => {
+              navigate('/');
+              removeAccessToken(ACCESS_TOKEN_KEY);
+            }}
+          />
+        }
+        fixed={true}
+      />
+    );
   };
 
   const renderRegisterNamePageHeader = () => {


### PR DESCRIPTION
## 🔥 Related Issues
resolved #466 

## 💜 작업 내용
- [x] 1차 리팩토링 후, 리뷰 받은 내용 최대한 반영
- [x] 중간에 홈으로 돌아가는 경우 액세스 코드 모두 삭제해줌
- [x] BackBtn.tsx 코드 수정 (버튼 클릭 시, 무조건 뒤(-1)로 가는게 아니라 step-1 을 해서 전 단계로 돌아가도록 수정)

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - BackBtn.tsx 코드 수정
  - 다시 수정한 코드로 첨부합니당!! 
  - step을 사용하는 경우에는 props로 step, setStep 넘겨주면 됩니당
  - step을 사용하지 않는 경우 props로 아무것도 안넘겨주면 됩니당
  ```
    interface BackBtnProps {
    step?: number;
    setStep?: React.Dispatch<SetStateAction<number>>;
    }

    const BackBtn = ({ step, setStep }: BackBtnProps) => {
    const navigate = useNavigate();

    const handleClickBack = () => {
      
      // 여기!!!!!
      step && setStep ? setStep(step - 1) : navigate(-1);
    };

    return <IcBackDark onClick={handleClickBack} />;
  };
  ```
  
  - `<` 아이콘을 사용하지만, 독단적인 기능을 하는 경우에는 공통 컴포넌트를 사용하지 않도록 구현
  ```
  const renderRegisterNamePageHeader = () => {
    return (
      <Header
        leftSection={<St.BlankSection></St.BlankSection>}
        title='회원가입'
        rightSection={
        
          // 여기
          <IcCancelDark
            onClick={() => {
              navigate('/login');
              setStep(0);
            }}
          />
          
        }
        progressBar={<ProgressBar curStep={1} maxStep={3} />}
      />
    );
  };
  ```

## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지
  - footer도 조건부 렌더링으로 분리 후, PageLayout을 상위로 올려 공통으로 관리하려 했으나 footer를 조건부 렌더링으로 분리하는 과정에서 어떤 방식으로 코드를 구현해도 계속 타입에러가 발생해서 일단 이 부분은 수정하지 않음
  - 코드가 복잡한 편은 아니라 분리하려고 하면 할 수 있을 것 같은데, 타입에러를 어떻게 해결하면 좋을지... 의견 부탁....드림요......ㅠ

<br />

