### PR TITLE
[Custom-NoDesign] NoDesign 페이지 통합

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,34 +1,35 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import ListPage from './page/ListPage';
-import MainPage from './page/MainPage';
-import LoginPage from './page/Login/LoginPage';
-import DetailPage from './page/DetailPage';
-import MyTattoo from './page/MyTattoo';
-import MyTattooDetail from './page/MyTattooDetail';
-import RegisterNamePage from './page/Register/RegisterNamePage';
-import RegisterPhoneNumPage from './page/Register/RegisterPhoneNumPage';
-import WelcomePage from './page/Welcome/WelcomePage';
-import ChargePage from './page/PointCharge/ChargePage';
-import TransferPage from './page/PointCharge/TransferPage';
-import SelectPage from './page/Custom/Common/SelectPage';
-import CompletePage from './page/Order/CompletePage';
-import OrderPage from './page/Order/OrderPage';
-import SelectKeywordPage from './page/Custom/HaveDesign/SelectKeywordPage';
-import OnBoardingPage from './page/Custom/Common/OnBoardingPage';
+import LoginCallback from './components/Login/LoginCallback';
+import ScrollToTop from './libs/hooks/ScrollTop';
 import CustomSizePage from './page/Custom/Common/CustomSizePage';
+import OnBoardingPage from './page/Custom/Common/OnBoardingPage';
+import SelectPage from './page/Custom/Common/SelectPage';
+import AdditionalRequestPage from './page/Custom/HaveDesign/AdditionalRequestPage';
+import CustomThemePage from './page/Custom/HaveDesign/CustomThemePage';
+import ReceiptPage from './page/Custom/HaveDesign/ReceiptPage';
+import SelectKeywordPage from './page/Custom/HaveDesign/SelectKeywordPage';
+import StylingColorPage from './page/Custom/HaveDesign/StylingColorPage';
 import CustomImgPage from './page/Custom/NoDesign/CustomImgPage';
 import CustomRequestPage from './page/Custom/NoDesign/CustomRequestPage';
-import CustomThemePage from './page/Custom/HaveDesign/CustomThemePage';
-import AdditionalRequestPage from './page/Custom/HaveDesign/AdditionalRequestPage';
+import NoDesignCustomPage from './page/Custom/NoDesign/NoDesignCustomPage';
 import PricePage from './page/Custom/PricePage';
-import ReceiptPage from './page/Custom/HaveDesign/ReceiptPage';
-import StylingColorPage from './page/Custom/HaveDesign/StylingColorPage';
 import CustomReferencePage from './page/CustomReference/CustomReferencePage';
+import DetailPage from './page/DetailPage';
+import ListPage from './page/ListPage';
+import LoginPage from './page/Login/LoginPage';
+import MainPage from './page/MainPage';
+import MyTattoo from './page/MyTattoo';
+import MyTattooDetail from './page/MyTattooDetail';
+import CompletePage from './page/Order/CompletePage';
+import OrderPage from './page/Order/OrderPage';
+import ChargePage from './page/PointCharge/ChargePage';
+import TransferPage from './page/PointCharge/TransferPage';
+import RegisterNamePage from './page/Register/RegisterNamePage';
+import RegisterPhoneNumPage from './page/Register/RegisterPhoneNumPage';
+import SavePage from './page/SavePage';
 import SearchPage from './page/Search/SearchPage';
 import SearchResultPage from './page/Search/SearchResultPage';
-import ScrollToTop from './libs/hooks/ScrollTop';
-import LoginCallback from './components/Login/LoginCallback';
-import SavePage from './page/SavePage';
+import WelcomePage from './page/Welcome/WelcomePage';
 
 const Router = () => {
   return (
@@ -66,6 +67,7 @@ const Router = () => {
         <Route path='/complete' element={<CompletePage />} />
         <Route path='/custom-reference' element={<CustomReferencePage />} />
         <Route path='/save' element={<SavePage />} />
+        <Route path='/noDesign' element={<NoDesignCustomPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Custom/NoDesign/NoDesignFooter.tsx
+++ b/src/components/Custom/NoDesign/NoDesignFooter.tsx
@@ -1,0 +1,74 @@
+import { useLocation } from 'react-router-dom';
+import { styled } from 'styled-components';
+
+interface NoDesignFooterProps {
+  isActiveNext?: boolean;
+  // navigateURL: string;
+  // haveDesign?: boolean;
+  // customInfo?: customInfoType;
+  // handDrawingImage?: File | null;
+  // customImages?: FileList | null;
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const NoDesignFooter = ({
+  isActiveNext = true,
+  // navigateURL,
+  // haveDesign,
+  // customInfo,
+  // handDrawingImage,
+  // customImages,
+  setStep,
+}: NoDesignFooterProps) => {
+  // const navigate = useNavigate();
+
+  const location = useLocation();
+  console.log(location.state);
+
+  const handleClickFooter = () => {
+    // {
+    //   isActiveNext &&
+    //     navigate(navigateURL, {
+    //       state: {
+    //         haveDesign: haveDesign,
+    //         customInfo: customInfo,
+    //         handDrawingImage: handDrawingImage,
+    //         customImages: customImages,
+    //       },
+    //     });
+    // }
+    {
+      isActiveNext && setStep((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <St.NoDesignFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
+      <St.FooterText>다음</St.FooterText>
+    </St.NoDesignFooter>
+  );
+};
+
+export default NoDesignFooter;
+
+const St = {
+  NoDesignFooter: styled.footer<{ $isActiveNext: boolean }>`
+    position: sticky;
+    bottom: 0;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 100%;
+    height: 7rem;
+
+    background-color: ${({ $isActiveNext, theme }) =>
+      $isActiveNext ? theme.colors.gray9 : theme.colors.gray3};
+  `,
+
+  FooterText: styled.p`
+    color: ${({ theme }) => theme.colors.white};
+    ${({ theme }) => theme.fonts.title_semibold_18};
+  `,
+};

--- a/src/components/Custom/NoDesign/NoDesignFooter.tsx
+++ b/src/components/Custom/NoDesign/NoDesignFooter.tsx
@@ -1,42 +1,12 @@
-import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 interface NoDesignFooterProps {
   isActiveNext?: boolean;
-  // navigateURL: string;
-  // haveDesign?: boolean;
-  // customInfo?: customInfoType;
-  // handDrawingImage?: File | null;
-  // customImages?: FileList | null;
   setStep: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const NoDesignFooter = ({
-  isActiveNext = true,
-  // navigateURL,
-  // haveDesign,
-  // customInfo,
-  // handDrawingImage,
-  // customImages,
-  setStep,
-}: NoDesignFooterProps) => {
-  // const navigate = useNavigate();
-
-  const location = useLocation();
-  console.log(location.state);
-
+const NoDesignFooter = ({ isActiveNext = true, setStep }: NoDesignFooterProps) => {
   const handleClickFooter = () => {
-    // {
-    //   isActiveNext &&
-    //     navigate(navigateURL, {
-    //       state: {
-    //         haveDesign: haveDesign,
-    //         customInfo: customInfo,
-    //         handDrawingImage: handDrawingImage,
-    //         customImages: customImages,
-    //       },
-    //     });
-    // }
     {
       isActiveNext && setStep((prev) => prev + 1);
     }

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -9,21 +9,29 @@ import NoDesignFooter from '../../../components/Custom/NoDesign/NoDesignFooter';
 import Header from '../../../components/Header';
 import PageLayout from '../../../components/PageLayout';
 
-const CustomImgPage = ({ setStep }: { setStep: React.Dispatch<React.SetStateAction<number>> }) => {
+interface CustomImgPageProps {
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+  customImages: FileList | undefined;
+  setCustomImages: React.Dispatch<React.SetStateAction<FileList | undefined>>;
+}
+
+const CustomImgPage = ({ setStep, customImages, setCustomImages }: CustomImgPageProps) => {
   // const CUSTOM_VIEW_COUNT = 2;
 
   const navigate = useNavigate();
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
-  const [customImages, setCustomImages] = useState<FileList>();
+  // const [customImages, setCustomImages] = useState<FileList>();
   const location = useLocation();
 
   // const haveDesign = location.state ? location.state.haveDesgin : null;
   // const prevCustomInfo = location.state ? location.state.customInfo : null;
 
   // state에 있는 img 파일 값 가져오기 (처음 넘어올 때는  값이 없으므로 에러 방지 필요)
-  const attachedImg =
-    location.state && location.state.customImages ? location.state.customImages : null;
+  // const attachedImg =
+  //   location.state && location.state.customImages ? location.state.customImages : null;
+
+  const attachedImg = customImages ? customImages : null;
 
   // useEffect(() => {
   //   if (!location.state) navigate('/onboarding');

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useState } from 'react';
-import CustomImg from '../../../components/Custom/NoDesgin/CustomImg';
-import Header from '../../../components/Header';
-import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
-import CancelBtn from '../../../common/Header/CancelBtn';
-import ProgressBar from '../../../common/ProgressBar';
-import PageLayout from '../../../components/PageLayout';
-import NextFooter from '../../../common/Footer/NextFooter';
-import { IcBackDark } from '../../../assets/icon';
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { IcBackDark } from '../../../assets/icon';
+import CancelBtn from '../../../common/Header/CancelBtn';
+import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
+import ProgressBar from '../../../common/ProgressBar';
+import CustomImg from '../../../components/Custom/NoDesgin/CustomImg';
+import NoDesignFooter from '../../../components/Custom/NoDesign/NoDesignFooter';
+import Header from '../../../components/Header';
+import PageLayout from '../../../components/PageLayout';
 
-const CustomImgPage = () => {
-  const CUSTOM_VIEW_COUNT = 2;
+const CustomImgPage = ({ setStep }: { setStep: React.Dispatch<React.SetStateAction<number>> }) => {
+  // const CUSTOM_VIEW_COUNT = 2;
 
   const navigate = useNavigate();
   const [modalOn, setModalOn] = useState(false);
@@ -18,21 +18,21 @@ const CustomImgPage = () => {
   const [customImages, setCustomImages] = useState<FileList>();
   const location = useLocation();
 
-  const haveDesign = location.state ? location.state.haveDesgin : null;
-  const prevCustomInfo = location.state ? location.state.customInfo : null;
+  // const haveDesign = location.state ? location.state.haveDesgin : null;
+  // const prevCustomInfo = location.state ? location.state.customInfo : null;
 
-  //state에 있는 img 파일 값 가져오기 (처음 넘어올 때는  값이 없으므로 에러 방지 필요)
+  // state에 있는 img 파일 값 가져오기 (처음 넘어올 때는  값이 없으므로 에러 방지 필요)
   const attachedImg =
     location.state && location.state.customImages ? location.state.customImages : null;
 
-  useEffect(() => {
-    if (!location.state) navigate('/onboarding');
-  }, [location.state, navigate]);
+  // useEffect(() => {
+  //   if (!location.state) navigate('/onboarding');
+  // }, [location.state, navigate]);
 
-  const customInfo = {
-    ...prevCustomInfo,
-    viewCount: CUSTOM_VIEW_COUNT,
-  };
+  // const customInfo = {
+  //   ...prevCustomInfo,
+  //   viewCount: CUSTOM_VIEW_COUNT,
+  // };
 
   const renderCustomImgPageHeader = () => {
     return (
@@ -63,12 +63,13 @@ const CustomImgPage = () => {
     <PageLayout
       renderHeader={renderCustomImgPageHeader}
       footer={
-        <NextFooter
+        <NoDesignFooter
           isActiveNext={isActiveNext}
-          navigateURL='/custom-request'
-          haveDesign={haveDesign}
-          customInfo={customInfo}
-          customImages={customImages}
+          // navigateURL='/custom-request'
+          // haveDesign={haveDesign}
+          // customInfo={customInfo}
+          // customImages={customImages}
+          setStep={setStep}
         />
       }
     >

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { IcBackDark } from '../../../assets/icon';
 import CancelBtn from '../../../common/Header/CancelBtn';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
@@ -18,42 +17,15 @@ interface CustomImgPageProps {
 const CustomImgPage = ({ setStep, customImages, setCustomImages }: CustomImgPageProps) => {
   // const CUSTOM_VIEW_COUNT = 2;
 
-  const navigate = useNavigate();
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
-  // const [customImages, setCustomImages] = useState<FileList>();
-  const location = useLocation();
-
-  // const haveDesign = location.state ? location.state.haveDesgin : null;
-  // const prevCustomInfo = location.state ? location.state.customInfo : null;
-
-  // state에 있는 img 파일 값 가져오기 (처음 넘어올 때는  값이 없으므로 에러 방지 필요)
-  // const attachedImg =
-  //   location.state && location.state.customImages ? location.state.customImages : null;
 
   const attachedImg = customImages ? customImages : null;
-
-  // useEffect(() => {
-  //   if (!location.state) navigate('/onboarding');
-  // }, [location.state, navigate]);
-
-  // const customInfo = {
-  //   ...prevCustomInfo,
-  //   viewCount: CUSTOM_VIEW_COUNT,
-  // };
 
   const renderCustomImgPageHeader = () => {
     return (
       <Header
-        leftSection={
-          <IcBackDark
-            onClick={() => {
-              navigate('/custom-size', {
-                state: location.state ? location.state : null,
-              });
-            }}
-          />
-        }
+        leftSection={<IcBackDark onClick={() => setStep((prev) => prev - 1)} />}
         title='커스텀 타투'
         rightSection={
           <CancelBtn

--- a/src/page/Custom/NoDesign/CustomImgPage.tsx
+++ b/src/page/Custom/NoDesign/CustomImgPage.tsx
@@ -62,16 +62,7 @@ const CustomImgPage = ({ setStep }: { setStep: React.Dispatch<React.SetStateActi
   return (
     <PageLayout
       renderHeader={renderCustomImgPageHeader}
-      footer={
-        <NoDesignFooter
-          isActiveNext={isActiveNext}
-          // navigateURL='/custom-request'
-          // haveDesign={haveDesign}
-          // customInfo={customInfo}
-          // customImages={customImages}
-          setStep={setStep}
-        />
-      }
+      footer={<NoDesignFooter isActiveNext={isActiveNext} setStep={setStep} />}
     >
       <CustomImg
         setIsActiveNext={setIsActiveNext}

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { IcBackDark } from '../../../assets/icon';
 import CancelBtn from '../../../common/Header/CancelBtn';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
@@ -9,40 +9,50 @@ import NoDesignFooter from '../../../components/Custom/NoDesign/NoDesignFooter';
 import Header from '../../../components/Header';
 import PageLayout from '../../../components/PageLayout';
 
+interface CustomRequestPageProps {
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+  name: string;
+  setName: React.Dispatch<React.SetStateAction<string>>;
+  demand: string;
+  setDemand: React.Dispatch<React.SetStateAction<string>>;
+}
+
 const CustomRequestPage = ({
   setStep,
-}: {
-  setStep: React.Dispatch<React.SetStateAction<number>>;
-}) => {
+  name,
+  setName,
+  demand,
+  setDemand,
+}: CustomRequestPageProps) => {
   const CUSTOM_VIEW_COUNT = 3;
 
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
   const location = useLocation();
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
-  const [name, setName] = useState('');
-  const [demand, setDemand] = useState('');
+  // const [name, setName] = useState('');
+  // const [demand, setDemand] = useState('');
 
-  const haveDesign = location.state ? location.state.haveDesign : null;
-  const prevCustomInfo = location.state ? location.state.customInfo : null;
-  const customImages = location.state ? location.state.customImages : null;
+  // const haveDesign = location.state ? location.state.haveDesign : null;
+  // const prevCustomInfo = location.state ? location.state.customInfo : null;
+  // const customImages = location.state ? location.state.customImages : null;
 
   //state에 있는 name, demand 값 가져오기 (처음 넘어올 때는 값이 없으므로 에러 방지 필요)
-  const writtenName =
-    location.state && location.state.customInfo.name ? location.state.customInfo.name : null;
-  const writtenDemand =
-    location.state && location.state.customInfo.demand ? location.state.customInfo.demand : null;
+  // const writtenName =
+  //   location.state && location.state.customInfo.name ? location.state.customInfo.name : null;
+  // const writtenDemand =
+  //   location.state && location.state.customInfo.demand ? location.state.customInfo.demand : null;
 
   // useEffect(() => {
   //   if (!location.state) navigate('/onboarding');
   // }, [location.state, navigate]);
 
-  const customInfo = {
-    ...prevCustomInfo,
-    viewCount: CUSTOM_VIEW_COUNT,
-    name: name,
-    demand: demand,
-  };
+  // const customInfo = {
+  //   ...prevCustomInfo,
+  //   viewCount: CUSTOM_VIEW_COUNT,
+  //   name: name,
+  //   demand: demand,
+  // };
 
   console.log(location.state, '###');
 
@@ -71,8 +81,8 @@ const CustomRequestPage = ({
         setIsActiveNext={setIsActiveNext}
         setName={setName}
         setDemand={setDemand}
-        writtenName={writtenName}
-        writtenDemand={writtenDemand}
+        writtenName={name}
+        writtenDemand={demand}
       />
     </PageLayout>
   );

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -49,15 +49,7 @@ const CustomRequestPage = ({
   const renderCustomRequestPageHeader = () => {
     return (
       <Header
-        leftSection={
-          <IcBackDark
-            onClick={() =>
-              navigate('/custom-img', {
-                state: location.state ? location.state : null,
-              })
-            }
-          />
-        }
+        leftSection={<IcBackDark onClick={() => setStep((prev) => prev - 1)} />}
         title='커스텀 타투'
         rightSection={
           <CancelBtn

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -1,15 +1,19 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { IcBackDark } from '../../../assets/icon';
-import NextFooter from '../../../common/Footer/NextFooter';
 import CancelBtn from '../../../common/Header/CancelBtn';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
 import ProgressBar from '../../../common/ProgressBar';
 import CustomRequset from '../../../components/Custom/NoDesign/CustomRequset';
+import NoDesignFooter from '../../../components/Custom/NoDesign/NoDesignFooter';
 import Header from '../../../components/Header';
 import PageLayout from '../../../components/PageLayout';
 
-const CustomRequestPage = () => {
+const CustomRequestPage = ({
+  setStep,
+}: {
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+}) => {
   const CUSTOM_VIEW_COUNT = 3;
 
   const navigate = useNavigate();
@@ -69,15 +73,7 @@ const CustomRequestPage = () => {
   return (
     <PageLayout
       renderHeader={renderCustomRequestPageHeader}
-      footer={
-        <NextFooter
-          isActiveNext={isActiveNext}
-          navigateURL='/price'
-          haveDesign={haveDesign}
-          customInfo={customInfo}
-          customImages={customImages}
-        />
-      }
+      footer={<NoDesignFooter isActiveNext={isActiveNext} setStep={setStep} />}
     >
       <CustomRequset
         setIsActiveNext={setIsActiveNext}

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { IcBackDark } from '../../../assets/icon';
+import NextFooter from '../../../common/Footer/NextFooter';
 import CancelBtn from '../../../common/Header/CancelBtn';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
 import ProgressBar from '../../../common/ProgressBar';
 import CustomRequset from '../../../components/Custom/NoDesign/CustomRequset';
 import Header from '../../../components/Header';
 import PageLayout from '../../../components/PageLayout';
-import NextFooter from '../../../common/Footer/NextFooter';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { IcBackDark } from '../../../assets/icon';
 
 const CustomRequestPage = () => {
   const CUSTOM_VIEW_COUNT = 3;
@@ -29,9 +29,9 @@ const CustomRequestPage = () => {
   const writtenDemand =
     location.state && location.state.customInfo.demand ? location.state.customInfo.demand : null;
 
-  useEffect(() => {
-    if (!location.state) navigate('/onboarding');
-  }, [location.state, navigate]);
+  // useEffect(() => {
+  //   if (!location.state) navigate('/onboarding');
+  // }, [location.state, navigate]);
 
   const customInfo = {
     ...prevCustomInfo,

--- a/src/page/Custom/NoDesign/CustomRequestPage.tsx
+++ b/src/page/Custom/NoDesign/CustomRequestPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { IcBackDark } from '../../../assets/icon';
 import CancelBtn from '../../../common/Header/CancelBtn';
 import CustomSizeEscapeModal from '../../../common/Modal/EscapeModal/CustomSizeEscapeModal';
@@ -24,37 +23,10 @@ const CustomRequestPage = ({
   demand,
   setDemand,
 }: CustomRequestPageProps) => {
-  const CUSTOM_VIEW_COUNT = 3;
+  // const CUSTOM_VIEW_COUNT = 3;
 
-  // const navigate = useNavigate();
-  const location = useLocation();
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
-  // const [name, setName] = useState('');
-  // const [demand, setDemand] = useState('');
-
-  // const haveDesign = location.state ? location.state.haveDesign : null;
-  // const prevCustomInfo = location.state ? location.state.customInfo : null;
-  // const customImages = location.state ? location.state.customImages : null;
-
-  //state에 있는 name, demand 값 가져오기 (처음 넘어올 때는 값이 없으므로 에러 방지 필요)
-  // const writtenName =
-  //   location.state && location.state.customInfo.name ? location.state.customInfo.name : null;
-  // const writtenDemand =
-  //   location.state && location.state.customInfo.demand ? location.state.customInfo.demand : null;
-
-  // useEffect(() => {
-  //   if (!location.state) navigate('/onboarding');
-  // }, [location.state, navigate]);
-
-  // const customInfo = {
-  //   ...prevCustomInfo,
-  //   viewCount: CUSTOM_VIEW_COUNT,
-  //   name: name,
-  //   demand: demand,
-  // };
-
-  console.log(location.state, '###');
 
   const renderCustomRequestPageHeader = () => {
     return (

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -1,0 +1,5 @@
+const NoDesignCustomPage = () => {
+  return <div>없어요 없다구요</div>;
+};
+
+export default NoDesignCustomPage;

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 // import CustomSizePage from '../Common/CustomSizePage';
 import PricePage from '../PricePage';
 import CustomImgPage from './CustomImgPage';
@@ -17,7 +17,11 @@ const NoDesignCustomPage = () => {
   //요청사항 state
   const [demand, setDemand] = useState('');
 
-  console.log('!!!', customImages);
+  console.log('!!!', customImages, '\n', name, '\n', demand);
+
+  useEffect(() => {
+    setStep(1);
+  }, []);
 
   switch (step) {
     // case 0:

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -7,8 +7,14 @@ const NoDesignCustomPage = () => {
   //커스텀 신청서 플로우에 따른 각 단계별 컴포넌트 렌더링 플래그
   const [step, setStep] = useState(0);
 
-  //CustomImg - 그려둔 도안 이미지 state
+  //step 0: CustomImg - 그려둔 도안 이미지 state
   const [customImages, setCustomImages] = useState<FileList>();
+
+  //step 1: CustomRequest
+  //타투 이름 state
+  const [name, setName] = useState('');
+  //요청사항 state
+  const [demand, setDemand] = useState('');
 
   console.log('!!!', customImages);
 
@@ -22,10 +28,18 @@ const NoDesignCustomPage = () => {
         />
       );
     case 1:
-      return <CustomRequestPage setStep={setStep} />;
+      return (
+        <CustomRequestPage
+          setStep={setStep}
+          name={name}
+          setName={setName}
+          demand={demand}
+          setDemand={setDemand}
+        />
+      );
 
     case 2:
-      return <PricePage />;
+      return <PricePage setStep={setStep} />;
   }
 };
 

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PricePage from '../PricePage';
 import CustomImgPage from './CustomImgPage';
 import CustomRequestPage from './CustomRequestPage';
 
@@ -22,6 +23,9 @@ const NoDesignCustomPage = () => {
       );
     case 1:
       return <CustomRequestPage setStep={setStep} />;
+
+    case 2:
+      return <PricePage />;
   }
 };
 

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -9,7 +9,7 @@ const NoDesignCustomPage = () => {
     case 0:
       return <CustomImgPage setStep={setStep} />;
     case 1:
-      return <CustomRequestPage />;
+      return <CustomRequestPage setStep={setStep} />;
   }
 };
 

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -3,11 +3,23 @@ import CustomImgPage from './CustomImgPage';
 import CustomRequestPage from './CustomRequestPage';
 
 const NoDesignCustomPage = () => {
+  //커스텀 신청서 플로우에 따른 각 단계별 컴포넌트 렌더링 플래그
   const [step, setStep] = useState(0);
+
+  //CustomImg - 그려둔 도안 이미지 state
+  const [customImages, setCustomImages] = useState<FileList>();
+
+  console.log('!!!', customImages);
 
   switch (step) {
     case 0:
-      return <CustomImgPage setStep={setStep} />;
+      return (
+        <CustomImgPage
+          setStep={setStep}
+          customImages={customImages}
+          setCustomImages={setCustomImages}
+        />
+      );
     case 1:
       return <CustomRequestPage setStep={setStep} />;
   }

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+// import CustomSizePage from '../Common/CustomSizePage';
 import PricePage from '../PricePage';
 import CustomImgPage from './CustomImgPage';
 import CustomRequestPage from './CustomRequestPage';
@@ -7,10 +8,10 @@ const NoDesignCustomPage = () => {
   //커스텀 신청서 플로우에 따른 각 단계별 컴포넌트 렌더링 플래그
   const [step, setStep] = useState(0);
 
-  //step 0: CustomImg - 그려둔 도안 이미지 state
+  //step 1: CustomImg - 그려둔 도안 이미지 state
   const [customImages, setCustomImages] = useState<FileList>();
 
-  //step 1: CustomRequest
+  //step 2: CustomRequest
   //타투 이름 state
   const [name, setName] = useState('');
   //요청사항 state
@@ -19,7 +20,9 @@ const NoDesignCustomPage = () => {
   console.log('!!!', customImages);
 
   switch (step) {
-    case 0:
+    // case 0:
+    //   return <CustomSizePage setStep={setStep} />;
+    case 1:
       return (
         <CustomImgPage
           setStep={setStep}
@@ -27,7 +30,7 @@ const NoDesignCustomPage = () => {
           setCustomImages={setCustomImages}
         />
       );
-    case 1:
+    case 2:
       return (
         <CustomRequestPage
           setStep={setStep}
@@ -38,7 +41,7 @@ const NoDesignCustomPage = () => {
         />
       );
 
-    case 2:
+    case 3:
       return <PricePage setStep={setStep} />;
   }
 };

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -17,8 +17,7 @@ const NoDesignCustomPage = () => {
   //요청사항 state
   const [demand, setDemand] = useState('');
 
-  console.log('!!!', customImages, '\n', name, '\n', demand);
-
+  //customSizePage가 공통으로 쓰여 아직 처리를 못해줘, step이 1부터 시작하도록 useEffect로 테스트 코드 추가. 추후 삭제 예정
   useEffect(() => {
     setStep(1);
   }, []);

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -1,5 +1,16 @@
+import { useState } from 'react';
+import CustomImgPage from './CustomImgPage';
+import CustomRequestPage from './CustomRequestPage';
+
 const NoDesignCustomPage = () => {
-  return <div>없어요 없다구요</div>;
+  const [step, setStep] = useState(0);
+
+  switch (step) {
+    case 0:
+      return <CustomImgPage setStep={setStep} />;
+    case 1:
+      return <CustomRequestPage />;
+  }
 };
 
 export default NoDesignCustomPage;

--- a/src/page/Custom/PricePage.tsx
+++ b/src/page/Custom/PricePage.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { styled } from 'styled-components';
+import { IcBackDark } from '../../assets/icon';
 import CancelBtn from '../../common/Header/CancelBtn';
+import CustomSizeEscapeModal from '../../common/Modal/EscapeModal/CustomSizeEscapeModal';
 import ProgressBar from '../../common/ProgressBar';
 import CountPrice from '../../components/Custom/CountPrice';
+import MakePublic from '../../components/Custom/MakePublic';
+import PriceFooter from '../../components/Custom/PriceFooter';
 import PriceHeading from '../../components/Custom/PriceHeading';
 import Header from '../../components/Header';
 import PageLayout from '../../components/PageLayout';
-import PriceFooter from '../../components/Custom/PriceFooter';
-import MakePublic from '../../components/Custom/MakePublic';
-import CustomSizeEscapeModal from '../../common/Modal/EscapeModal/CustomSizeEscapeModal';
-import { styled } from 'styled-components';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { IcBackDark } from '../../assets/icon';
 
 const PricePage = () => {
   const [modalOn, setModalOn] = useState(false);
@@ -36,9 +36,9 @@ const PricePage = () => {
   const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
   const backNavigateURL = haveDesign ? '/additional-request' : '/custom-request';
 
-  useEffect(() => {
-    if (!location.state) navigate('/onboarding');
-  }, [location.state, navigate]);
+  // useEffect(() => {
+  //   if (!location.state) navigate('/onboarding');
+  // }, [location.state, navigate]);
 
   const customInfo = {
     ...prevCustomInfo,


### PR DESCRIPTION
## 🔥 Related Issues
resolved #467 

## 💜 작업 내용
- [x] CustomImgPage, CustomRequestPage 통합
- [x] step을 기준으로 switch case -> 각각 다른 페이지의 컴포넌트들 불러오기

## ✅ PR Point

### 1️⃣ step에 따른 조건부 렌더링
: switch case 문으로 각각의 페이지들을 step에 따라 return 하도록 구현
```tsx
switch (step) {
    // case 0:
    //   return <CustomSizePage setStep={setStep} />;
    case 1:
      return (
        <CustomImgPage
          setStep={setStep}
          customImages={customImages}
          setCustomImages={setCustomImages}
        />
      );
    case 2:
      return (
        <CustomRequestPage
          setStep={setStep}
          name={name}
          setName={setName}
          demand={demand}
          setDemand={setDemand}
        />
      );

    case 3:
      return <PricePage setStep={setStep} />;
  }
```
*❓ 페이지 레이아웃을 꺼내오는것이 아닌 페이지로 썼던 컴포넌트 자체를 가져온 이유:
-> custom 플로우는 step이 많고 복잡해 최대한 코드를 간소화 하는게 좋다 생각했기 때문. pagelayout , renderHeader 함수를 하나하나 가져오는것보다 이미 pageLayout으로 구현된 컴포넌트 자체를 return 하는 것이 더 간소화 할 수 있는 방안이라 생각했습니다.
<br/>
<hr/>

### 2️⃣ 최상단 (통합된 페이지인 NoDesignCustomPage)에 빼온 state 들
☑️ CustomImgPage : 그려둔 도안 이미지 FileList를 담는 customImages를 최상단에서 관리 해 step에 따라 다른 컴포넌트가 렌더링 되어도 유지될수 있도록 함

☑️ CustomRequestPage : 타투 이름을 담는 name, 요청 사항을 담는 demand state를 최상단에서 관리 해 step에 따라 다른 컴포넌트가 렌더링 되어도 유지될수 있도록 함

```tsx
  //step 1: CustomImg - 그려둔 도안 이미지 state
  const [customImages, setCustomImages] = useState<FileList>();

  //step 2: CustomRequest
  //타투 이름 state
  const [name, setName] = useState('');
  //요청사항 state
  const [demand, setDemand] = useState('');
```

*  ❓ `isActiveNext`, `modalOn` useState들은 각 컴포넌트에 중복되는데, 최상단(통합된 페이지인 NoDesignCustomPage)으로 빼서 공통으로 쓰지 않은 이유:
 -> isActiveNext는 각 단계별 cta 푸터 버튼의 활성화, 비활성화 여부를 판단하는 플래그입니다. 따라서 최상단으로 빼서 공통으로 사용했을 때보다 각 컴포넌트 내에서 사용하는 것이 의존성을 줄이는 방법이라 생각했습니다. 또한, 실제로 최상단으로 빼보았더니 이전 step에서 활성화 되고 다음 step으로 넘어갔을 때 => 다시 활성화를 해 줘야 하는 과정이 필요했고, 이 처리를 하는 코드를 하나씩 또 작성하는 방법보다 중복되는 코드라도 각 컴포넌트(각 페이지) 내에서 관리하는것이 좋다고 생각했습니다. 제 개인적인 생각이니 ㅎㅎ 의견 많이주세요 !!
-> 모달을 켜고 끄는 플래그인 modalOn state도 같은 이유로 최상단으로 가져오지 않았습니다!

<br/>
<hr/>

### 🚨 참고할 사항
* 1) Footer 관련 :
지금 지민언니(haveDesign)랑 `nextFooter`를 공통으로 사용하고 있는데 페이지 통합 하는 과정에서 `nextFooter`를 수정해야 합니다. 각자 작업하는 과정에서 한 명이 수정하면 충돌이 발생할것 같아 우선 nextFooter를 복붙해서 `noDesignFooter`라는 혼자만 쓰는 footer를 만들어서 쓰고, 추후에 공통되는 부분이 많을 시 합치기로 했습니당!
```tsx
// CustomImgPage.tsx


return (
    <PageLayout
      renderHeader={renderCustomImgPageHeader}
//여기를 수정해서 사용했음!
      footer={<NoDesignFooter isActiveNext={isActiveNext} setStep={setStep} />}
    >
      <CustomImg
        setIsActiveNext={setIsActiveNext}
        setCustomImages={setCustomImages}
        attachedImg={attachedImg}
      />
    </PageLayout>
  );
```

* 2) SelectSizePage, PricePage 관련:
공통으로 사용되는 페이지인 SelectSizePage, PricePage는 지금 코드를 고치면 충돌이 날것 같아 로컬에서 테스트만 해놓고, 주석 처리 혹은 코드를 날린 상태입니다! 지민언니랑 합칠 때 구현할 예정입니당 아래 화면 녹화로 플로우만 참고 부탁

### 🚨 물어보고 싶은 점
* 각 단계별 페이지에서 가져오는 state들을 이전에 navigate로 state를 전달하던 방식처럼 하나의 객체 (ex. customInfo 객체)로 관리하는게 좋을까요, 아니면 지금 제가 구현한 방식처럼 각각의 state들로 관리하고 추후 patch 시 합쳐서 보내는 방식이 더 효율적일까용? 궁금합니🐿



## 😡 Trouble Shooting
- x


## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/2eec6758-f69a-4167-91c3-8e44ac279a11

=> PricePage까지 테스트 + 뒤로가기도 점검하면 이렇게 됩니다잉

https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/cb4b20ea-a6fd-4b86-92a2-184e85846265

=> SelectSizePage까지 앞에 붙이면 이렇게 됩니다!
