### PR TITLE
[LoginPage] 전화번호 인증 부분 코드 리팩토링

### DIFF
--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -26,10 +26,8 @@ const RegisterPhoneNumForm = () => {
   const navigate = useNavigate();
   // 입력한 전화번호 자릿수
   const [numLength, setNumLength] = useState(0);
-  // toast message
   const [toast, setToast] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
-  const [isRequired, setIsRequired] = useState(false);
   // 인증번호와 입력번호의 일치 여부 확인하기 위한 상태
   const [isError, setIsError] = useState(false);
   // 입력한 인증번호 자릿수
@@ -116,7 +114,6 @@ const RegisterPhoneNumForm = () => {
       });
 
     setToast(true);
-    setIsRequired(!isRequired);
   };
 
   const handleChangeCertificationInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -161,12 +158,7 @@ const RegisterPhoneNumForm = () => {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeInputContent(e)}
           onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 13, 'phoneNum')}
         ></St.InputContent>
-        <St.SendMessageBtn
-          type='button'
-          $isvisible={isVisible}
-          $length={numLength}
-          onClick={handleClickSendMessageBtn}
-        >
+        <St.SendMessageBtn type='button' $length={numLength} onClick={handleClickSendMessageBtn}>
           {isVisible && numLength === 13 ? '재인증' : '인증하기'}
           {toast && <Toast setToast={setToast} text='인증번호가 발송되었습니다.' />}
         </St.SendMessageBtn>
@@ -232,7 +224,7 @@ const St = {
     }
   `,
 
-  SendMessageBtn: styled.button<{ $isvisible: boolean; $length: number }>`
+  SendMessageBtn: styled.button<{ $length: number }>`
     width: 9.2rem;
     height: 4.5rem;
 
@@ -241,8 +233,8 @@ const St = {
 
     color: ${({ theme }) => theme.colors.white};
 
-    background-color: ${({ $isvisible, theme, $length }) =>
-      $isvisible || $length === 13 ? theme.colors.gray7 : theme.colors.gray3};
+    background-color: ${({ theme, $length }) =>
+      $length === 13 ? theme.colors.gray7 : theme.colors.gray3};
 
     ${({ theme }) => theme.fonts.title_semibold_16};
   `,

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -84,36 +84,34 @@ const RegisterPhoneNumForm = () => {
     const ACCESS_TOKEN_KEY = 'accesstoken';
     const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
 
-    axios
-      .post(
-        `https://api.tattour.shop/sms/send/verification-code`,
-        // post body
-        {
-          phoneNumber: `${phoneNum}`,
-        },
-        // request headers
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
+    if (numLength === 13) {
+      axios
+        .post(
+          `https://api.tattour.shop/sms/send/verification-code`,
+          // post body
+          {
+            phoneNumber: `${phoneNum}`,
           },
-        },
-      )
-      .then(() => {
-        // 인증번호 입력 폼 나옴
-        setIsVisible(true);
-
-        // 인증번호 입력 폼이 나온 경우
-        if (isVisible) {
+          // request headers
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          },
+        )
+        .then(() => {
+          // 인증번호 입력 폼 나옴
+          setIsVisible(true);
+          setToast(true);
           setIsTimeout(false);
           setLeftTime(MINUTES_IN_MS);
           setCertificationLen(1);
-        }
-      })
-      .catch((Error: object) => {
-        console.log(Error);
-      });
-
-    setToast(true);
+        })
+        .catch((Error: object) => {
+          console.log(Error);
+        });
+    }
+    setIsVisible(false);
   };
 
   const handleChangeCertificationInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -158,7 +156,11 @@ const RegisterPhoneNumForm = () => {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeInputContent(e)}
           onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 13, 'phoneNum')}
         ></St.InputContent>
-        <St.SendMessageBtn type='button' $length={numLength} onClick={handleClickSendMessageBtn}>
+        <St.SendMessageBtn
+          type='button'
+          $length={numLength}
+          onClick={handleClickSendMessageBtn}
+        >
           {isVisible && numLength === 13 ? '재인증' : '인증하기'}
           {toast && <Toast setToast={setToast} text='인증번호가 발송되었습니다.' />}
         </St.SendMessageBtn>
@@ -278,3 +280,4 @@ const St = {
 };
 
 export default RegisterPhoneNumForm;
+

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -30,8 +30,6 @@ const RegisterPhoneNumForm = () => {
   const [isVisible, setIsVisible] = useState(false);
   // 인증번호와 입력번호의 일치 여부 확인하기 위한 상태
   const [isError, setIsError] = useState(false);
-  // 입력한 인증번호 자릿수
-  const [certificationLen, setCertificationLen] = useState(0);
   const [isTimeout, setIsTimeout] = useState(false);
   const [leftTime, setLeftTime] = useState<number>(MINUTES_IN_MS);
 
@@ -105,7 +103,6 @@ const RegisterPhoneNumForm = () => {
           setToast(true);
           setIsTimeout(false);
           setLeftTime(MINUTES_IN_MS);
-          setCertificationLen(0);
         })
         .catch((Error: object) => {
           console.log(Error);
@@ -119,7 +116,6 @@ const RegisterPhoneNumForm = () => {
       ...inputData,
       [e.target.name]: e.target.value,
     });
-    setCertificationLen(e.target.value.length);
 
     checkCertificationNum(e);
   };
@@ -171,7 +167,11 @@ const RegisterPhoneNumForm = () => {
           <St.CertificationInput
             name='certificationNum'
             type='number'
-            id={(isError && certificationLen === 6) || isTimeout ? 'errorInput' : 'successInput'}
+            id={
+              (isError && certificationNum.length === 6) || isTimeout
+                ? 'errorInput'
+                : 'successInput'
+            }
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeCertificationInput(e)}
             disabled={isTimeout ? true : false}
             onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 6, 'onlyNum')}
@@ -184,7 +184,7 @@ const RegisterPhoneNumForm = () => {
             setLeftTime={setLeftTime}
           />
 
-          {((isError && certificationLen === 6) || isTimeout) && (
+          {((isError && certificationNum.length === 6) || isTimeout) && (
             <ErrorMessage isTimeout={isTimeout} />
           )}
         </St.CertificationInputWrapper>

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -31,7 +31,7 @@ const RegisterPhoneNumForm = () => {
   // 인증번호와 입력번호의 일치 여부 확인하기 위한 상태
   const [isError, setIsError] = useState(false);
   // 입력한 인증번호 자릿수
-  const [certificationLen, setCertificationLen] = useState(1);
+  const [certificationLen, setCertificationLen] = useState(0);
   const [isTimeout, setIsTimeout] = useState(false);
   const [leftTime, setLeftTime] = useState<number>(MINUTES_IN_MS);
 
@@ -105,7 +105,7 @@ const RegisterPhoneNumForm = () => {
           setToast(true);
           setIsTimeout(false);
           setLeftTime(MINUTES_IN_MS);
-          setCertificationLen(1);
+          setCertificationLen(0);
         })
         .catch((Error: object) => {
           console.log(Error);

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -121,11 +121,15 @@ const RegisterPhoneNumForm = () => {
     });
     setCertificationLen(e.target.value.length);
 
+    checkCertificationNum(e);
+  };
+
+  const checkCertificationNum = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length === 6) {
       api
         .get(`/user/phonenumber/verification`, {
           params: {
-            verificationCode: `${certificationNum}`,
+            verificationCode: `${e.target.value}`,
           },
         })
         .then((res: resProps) => {
@@ -156,11 +160,7 @@ const RegisterPhoneNumForm = () => {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangeInputContent(e)}
           onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 13, 'phoneNum')}
         ></St.InputContent>
-        <St.SendMessageBtn
-          type='button'
-          $length={numLength}
-          onClick={handleClickSendMessageBtn}
-        >
+        <St.SendMessageBtn type='button' $length={numLength} onClick={handleClickSendMessageBtn}>
           {isVisible && numLength === 13 ? '재인증' : '인증하기'}
           {toast && <Toast setToast={setToast} text='인증번호가 발송되었습니다.' />}
         </St.SendMessageBtn>
@@ -280,4 +280,3 @@ const St = {
 };
 
 export default RegisterPhoneNumForm;
-


### PR DESCRIPTION
## 🔥 Related Issues
resolved #456 

## 💜 작업 내용
- [x] input value 부분 구조 분해 할당 활용하여 코드 수정
- [x] 함수 분리 (하나의 함수가 한 가지 기능만 하도록)
- [x] 없어도 되는 state 삭제

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - input의 value를 관리하던 여러 개의 state를 구조분해할당을 활용한 코드로 수정했습니다.
  ```
    const [inputData, setInputData] = useState({
    phoneNum: '',
    certificationNum: '',
  });

  const { phoneNum, certificationNum } = inputData;
  ```
  ```
  setInputData({
      ...inputData,
      [e.target.name]: e.target.value,
    });
  ```
  
  - 사용하지 않아도 되는 state를 삭제하고, 기능이 겹치는 state는 하나의 상태로 대체할 수 있게 코드 수정했습니다.
  - 코드를 수정하면서 몇몇 기능이 제대로 동작하지 않는 이슈 해결했습니다. 
