### PR TITLE
[LoginPage] 타이머 성능 개선

### DIFF
--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -1,13 +1,13 @@
 import { styled } from 'styled-components';
-import sliceMaxLength from '../../utils/sliceMaxLength';
 import React, { SetStateAction, useReducer, useState } from 'react';
-import Toast from '../../common/ToastMessage/Toast';
-import Timer from './Timer';
-import ErrorMessage from './ErrorMessage';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
 import { reducer } from '../../libs/reducers/registerReducer';
+import sliceMaxLength from '../../utils/sliceMaxLength';
+import Toast from '../../common/ToastMessage/Toast';
+import Timer from './Timer';
+import ErrorMessage from './ErrorMessage';
 
 interface RegisterPhoneNumFormProps {
   setStep: React.Dispatch<SetStateAction<number>>;

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 import React, { SetStateAction, useReducer, useState } from 'react';
-import { useLocation} from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
 import { reducer } from '../../libs/reducers/registerReducer';
@@ -279,6 +279,19 @@ const St = {
 
     &#errorInput {
       border: 0.1rem solid ${({ theme }) => theme.colors.red};
+    }
+
+    // input type 'number' 화살표 없애기
+    /* Chrome, Safari, Edge, Opera */
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    /* Firefox  */
+    &[type='number'] {
+      -moz-appearance: textfield;
     }
   `,
 };

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -42,6 +42,7 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
     isVisible: false,
     isError: false,
     leftTime: MINUTES_IN_MS,
+    resetTime: false,
   });
 
   // 사용자 정보를 패치하는 함수
@@ -183,7 +184,11 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
             onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 6, 'onlyNum')}
             placeholder='인증번호를 입력해주세요'
           ></St.CertificationInput>
-          <Timer isTimeout={isTimeout} setIsTimeout={setIsTimeout} />
+          <Timer
+            isTimeout={isTimeout}
+            setIsTimeout={setIsTimeout}
+            resetTime={registerState.resetTime}
+          />
 
           {((registerState.isError && certificationNum.length === 6) || isTimeout) && (
             <ErrorMessage isTimeout={isTimeout} />

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 import React, { SetStateAction, useReducer, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation} from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
 import { reducer } from '../../libs/reducers/registerReducer';
@@ -27,7 +27,6 @@ interface usePatchProfileProps {
 
 const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
-  const navigate = useNavigate();
   const [toast, setToast] = useState(false);
   const [isTimeout, setIsTimeout] = useState(false);
   const [inputData, setInputData] = useState({
@@ -57,7 +56,6 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
         {},
       )
       .then(() => {
-        navigate('/login');
         setStep(3);
       })
       .catch((Error: object) => {

--- a/src/components/Register/Timer.tsx
+++ b/src/components/Register/Timer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef } from 'react';
+import { memo, useEffect, useReducer, useRef } from 'react';
 import { styled } from 'styled-components';
 import { reducer } from '../../libs/reducers/registerReducer';
 
@@ -7,7 +7,7 @@ interface TimerProps {
   setIsTimeout: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
+const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
   const INTERVAL = 1000;
 
@@ -46,7 +46,7 @@ const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
       {isTimeout ? '시간 만료' : `${minutes} : ${second}`}
     </St.AuthTimer>
   );
-};
+});
 
 const St = {
   AuthTimer: styled.span<{ $isTimeout: boolean }>`

--- a/src/components/Register/Timer.tsx
+++ b/src/components/Register/Timer.tsx
@@ -11,7 +11,7 @@ const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
   const INTERVAL = 1000;
 
-  const [state, dispatch] = useReducer(reducer, {
+  const [timerState, dispatch] = useReducer(reducer, {
     isVisible: false,
     isError: false,
     leftTime: MINUTES_IN_MS,
@@ -20,8 +20,8 @@ const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
   const timer = useRef(0);
 
   // padStart(2, '0'): 문자열의 길이는 2로 하고, 빈 곳이 있으면 0으로 채워넣어줌.
-  const minutes = String(Math.floor((state.leftTime / (1000 * 60)) % 60)).padStart(2, '0');
-  const second = String(Math.floor((state.leftTime / 1000) % 60)).padStart(2, '0');
+  const minutes = String(Math.floor((timerState.leftTime / (1000 * 60)) % 60)).padStart(2, '0');
+  const second = String(Math.floor((timerState.leftTime / 1000) % 60)).padStart(2, '0');
 
   useEffect(() => {
     // setInterval: 두 번째 인자(시간(ms))를 간격으로 첫 번째 인자(코드) 실행
@@ -30,7 +30,7 @@ const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
       dispatch({ type: 'SET_LEFT_TIME', payload: INTERVAL });
     }, INTERVAL);
 
-    if (state.leftTime <= 0) {
+    if (timerState.leftTime <= 0) {
       // timer 반복 중단
       clearInterval(timer.current);
       setIsTimeout(true);
@@ -39,7 +39,7 @@ const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
     return () => {
       clearInterval(timer.current);
     };
-  }, [state.leftTime, setIsTimeout]);
+  }, [timerState.leftTime, setIsTimeout]);
 
   return (
     <St.AuthTimer $isTimeout={isTimeout}>

--- a/src/components/Register/Timer.tsx
+++ b/src/components/Register/Timer.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useReducer } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
 import { styled } from 'styled-components';
 import { reducer } from '../../libs/reducers/registerReducer';
 
@@ -7,7 +7,7 @@ interface TimerProps {
   setIsTimeout: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
+const Timer = ({ isTimeout, setIsTimeout }: TimerProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
   const INTERVAL = 1000;
 
@@ -17,25 +17,27 @@ const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
     leftTime: MINUTES_IN_MS,
   });
 
+  const timer = useRef(0);
+
   // padStart(2, '0'): 문자열의 길이는 2로 하고, 빈 곳이 있으면 0으로 채워넣어줌.
   const minutes = String(Math.floor((state.leftTime / (1000 * 60)) % 60)).padStart(2, '0');
   const second = String(Math.floor((state.leftTime / 1000) % 60)).padStart(2, '0');
 
   useEffect(() => {
     // setInterval: 두 번째 인자(시간(ms))를 간격으로 첫 번째 인자(코드) 실행
-    const timer = setInterval(() => {
+    timer.current = setInterval(() => {
       // 1초씩 감소
       dispatch({ type: 'SET_LEFT_TIME', payload: INTERVAL });
     }, INTERVAL);
 
     if (state.leftTime <= 0) {
       // timer 반복 중단
-      clearInterval(timer);
+      clearInterval(timer.current);
       setIsTimeout(true);
     }
 
     return () => {
-      clearInterval(timer);
+      clearInterval(timer.current);
     };
   }, [state.leftTime, setIsTimeout]);
 
@@ -44,7 +46,7 @@ const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
       {isTimeout ? '시간 만료' : `${minutes} : ${second}`}
     </St.AuthTimer>
   );
-});
+};
 
 const St = {
   AuthTimer: styled.span<{ $isTimeout: boolean }>`

--- a/src/components/Register/Timer.tsx
+++ b/src/components/Register/Timer.tsx
@@ -4,10 +4,11 @@ import { reducer } from '../../libs/reducers/registerReducer';
 
 interface TimerProps {
   isTimeout: boolean;
+  resetTime: boolean;
   setIsTimeout: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
+const Timer = memo(({ isTimeout, setIsTimeout, resetTime }: TimerProps) => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
   const INTERVAL = 1000;
 
@@ -15,6 +16,7 @@ const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
     isVisible: false,
     isError: false,
     leftTime: MINUTES_IN_MS,
+    resetTime: false,
   });
 
   const timer = useRef(0);
@@ -40,6 +42,10 @@ const Timer = memo(({ isTimeout, setIsTimeout }: TimerProps) => {
       clearInterval(timer.current);
     };
   }, [timerState.leftTime, setIsTimeout]);
+
+  useEffect(() => {
+    dispatch({ type: 'RESET_LEFT_TIME' });
+  }, [resetTime]);
 
   return (
     <St.AuthTimer $isTimeout={isTimeout}>

--- a/src/libs/reducers/registerReducer.ts
+++ b/src/libs/reducers/registerReducer.ts
@@ -2,6 +2,7 @@ type State = {
   isVisible: boolean;
   isError: boolean;
   leftTime: number;
+  resetTime: boolean;
 };
 
 type Action =
@@ -22,6 +23,7 @@ export const reducer = (state: State, action: Action): State => {
         ...state,
         isVisible: true,
         leftTime: MINUTES_IN_MS,
+        resetTime: !state.resetTime,
       };
 
     // 인증번호 입력 폼을 사라지게 하는 동작

--- a/src/libs/reducers/registerReducer.ts
+++ b/src/libs/reducers/registerReducer.ts
@@ -9,7 +9,8 @@ type Action =
   | { type: 'HIDE_CERTIFICATION_FORM' }
   | { type: 'VERIFIED_NOT_FAILED' }
   | { type: 'VERIFIED_FAILED' }
-  | { type: 'SET_LEFT_TIME'; payload: number };
+  | { type: 'SET_LEFT_TIME'; payload: number }
+  | { type: 'RESET_LEFT_TIME' };
 
 export const reducer = (state: State, action: Action): State => {
   const MINUTES_IN_MS = 5 * 60 * 1000;
@@ -38,6 +39,9 @@ export const reducer = (state: State, action: Action): State => {
     // 타이머 시간이 줄어들게 하는 동작
     case 'SET_LEFT_TIME':
       return { ...state, leftTime: state.leftTime - action.payload };
+
+    case 'RESET_LEFT_TIME':
+      return { ...state, leftTime: MINUTES_IN_MS };
     default:
       throw new Error('Unhandled action');
   }


### PR DESCRIPTION
## 🔥 Related Issues
closed #458  

## 💜 작업 내용
- [x] React.memo, useRef 통한 타이머 성능 개선
- [x] 인증번호 재전송 버튼 클릭 시, 타이머 초기화 안되는 이슈 해결

## ✅ PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
    - **`React.memo`**
        - 부모 컴포넌트의 값이 변했을 때, 자식 컴포넌트에 발생할 불필요한 리렌더링을 방지하기 위해 사용
        - React.memo로 감싼 컴포넌트는 이전에 전달된 props와 현재의 props를 비교하여 변경이 있을 경우에만 리렌더링하기 때문에 렌더링 최적화 가능
        - Timer 컴포넌트 전체를 memo로 감싸줌
    
    <br />
    
    - **`useRef`**
        - setState는 값이 변하면 리렌더링이 되지만, useRef는 current 값이 변하더라도 리렌더링 되지 않기 때문에 렌더링 최적화를 할 수 있음
    
    ```
    // Timer.tsx
    const timer = useRef(0);
    
    useEffect(() => {
        // setInterval: 두 번째 인자(시간(ms))를 간격으로 첫 번째 인자(코드) 실행
        timer.current = setInterval(() => {
          // 1초씩 감소
          dispatch({ type: 'SET_LEFT_TIME', payload: INTERVAL });
        }, INTERVAL);
    
        if (timerState.leftTime <= 0) {
          // timer 반복 중단
          clearInterval(timer.current);
          setIsTimeout(true);
        }
    
        return () => {
          clearInterval(timer.current);
        };
      }, [timerState.leftTime, setIsTimeout]);
    ```
    
    <br />
    
    - 타이머 초기화 안되는 이슈 해결
        - reducer에 전화번호 인증을 위한 버튼 클릭 여부를 확인하기 위한 state 추가
        
        ```tsx
        // registerReducer.ts
        case 'SHOW_CERTIFICATION_FORM':
            return {
              ...state,
              isVisible: true,
              leftTime: MINUTES_IN_MS,
        
        		  // 여기!!!
              resetTime: !state.resetTime,
            };
        ```
        
        - 타이머 초기화를 위한 action 추가
        
        ```tsx
        // registerReducer.ts
        case 'RESET_LEFT_TIME':
            return { ...state, leftTime: MINUTES_IN_MS };
        ```
        
        - resetTime 값이 변할 때마다 leftTime 초기화
        
        ```tsx
        // Timer.tsx
        useEffect(() => {
            dispatch({ type: 'RESET_LEFT_TIME' });
          }, [resetTime]);
        ```
        
        <br />
        
    - 성능 체크 결과 (시간은 둘 다 동일하게 30초로 조정한 후 체크함)
      - 전 (타이머가 적용되는 부분 외의 여러 컴포넌트에서 렌더링이 일어남)
      <img width="1678" alt="스크린샷 2023-08-14 오후 9 13 32" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/ed71c10b-c130-42ee-b3b3-bf450de6cf79">
        
      - 후 (타이머가 적용되는 부분에만 렌더링이 일어남)
      <img width="1678" alt="스크린샷 2023-08-14 오후 9 13 23" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/775711a6-e9f1-48a5-ba7a-4b626655aa6b">


<br />

## 😡 Trouble Shooting

- 더 최적화할 내용이 있다면 리뷰 많이 남겨주세욥!!!

<br />

## ☀️ 스크린샷 / GIF / 화면 녹화

- `재인증/인증하기` 버튼 클릭 시 나오는 화면 (시간은 임의로 3초로 조정해서 녹화함)

https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/9c87ee48-f093-4ab9-9785-2379efafdd65


