### PR TITLE
[ChargePage] 충전액 0원일 때도 다음 cta 비활성화되도록 수정

### DIFF
--- a/src/components/PointCharge/Charge.tsx
+++ b/src/components/PointCharge/Charge.tsx
@@ -33,6 +33,7 @@ const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
       setIsActiveNext(false);
     } else if (removedCommaValue % 1000 === 0) {
       //1000원 단위인지 확인
+      setIsZeroWarning(false);
       setIsWarning(false);
       setIsActiveNext(true);
     } else {

--- a/src/components/PointCharge/Charge.tsx
+++ b/src/components/PointCharge/Charge.tsx
@@ -9,6 +9,7 @@ interface ChargeProps {
 
 const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
   const [isWarning, setIsWarning] = useState(false);
+  const [isZeroWarning, setIsZeroWarning] = useState(false);
   const [parsedPrice, setParsedPrice] = useState('');
 
   const handleChangeChargeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -25,11 +26,18 @@ const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
     setChargeAmount(removedCommaValue);
     setParsedPrice(removedCommaValue.toLocaleString());
 
-    //1000원 단위인지 확인
-    if (removedCommaValue % 1000 === 0) {
+    if (removedCommaValue === 0) {
+      //0원이면 경고 메시지
+      setIsZeroWarning(true);
+      setIsWarning(true);
+      setIsActiveNext(false);
+    } else if (removedCommaValue % 1000 === 0) {
+      //1000원 단위인지 확인
       setIsWarning(false);
       setIsActiveNext(true);
     } else {
+      //0원이 아닌데, 1000원 단위가 아닐 때 경고 메시지
+      setIsZeroWarning(false);
       setIsWarning(true);
       setIsActiveNext(false);
     }

--- a/src/components/PointCharge/Charge.tsx
+++ b/src/components/PointCharge/Charge.tsx
@@ -12,6 +12,16 @@ const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
   const [isZeroWarning, setIsZeroWarning] = useState(false);
   const [parsedPrice, setParsedPrice] = useState('');
 
+  //input에 금액을 입력 했을 때 1) 0원, 2) 1000원이 아닌 단위 예외 처리를 해 주는 함수
+  const updateStateBasedOnValue = (removedCommaValue: number) => {
+    const isZero = removedCommaValue === 0;
+    const isThousandMultiple = removedCommaValue % 1000 === 0;
+
+    setIsZeroWarning(isZero); //0원일 때 감지
+    setIsWarning(isZero || !isThousandMultiple); //0원일 때 혹은 1000원 단위가 아닐 때 경고 메시지 띄우기
+    setIsActiveNext(!isZero && isThousandMultiple); // 0원이 아니고, 1000원 단위일 때만 다음 버튼 활성화
+  };
+
   const handleChangeChargeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     // 숫자가 아닌 text가 들어왔을 때 방지
     const re = /[^0-9]/gi;
@@ -26,22 +36,8 @@ const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
     setChargeAmount(removedCommaValue);
     setParsedPrice(removedCommaValue.toLocaleString());
 
-    if (removedCommaValue === 0) {
-      //0원이면 경고 메시지
-      setIsZeroWarning(true);
-      setIsWarning(true);
-      setIsActiveNext(false);
-    } else if (removedCommaValue % 1000 === 0) {
-      //1000원 단위인지 확인
-      setIsZeroWarning(false);
-      setIsWarning(false);
-      setIsActiveNext(true);
-    } else {
-      //0원이 아닌데, 1000원 단위가 아닐 때 경고 메시지
-      setIsZeroWarning(false);
-      setIsWarning(true);
-      setIsActiveNext(false);
-    }
+    // 금액 입력 시 예외 처리 해주는 함수 호출
+    updateStateBasedOnValue(removedCommaValue);
   };
 
   const ERR_MSG_CONTENT = isZeroWarning

--- a/src/components/PointCharge/Charge.tsx
+++ b/src/components/PointCharge/Charge.tsx
@@ -43,6 +43,10 @@ const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
     }
   };
 
+  const ERR_MSG_CONTENT = isZeroWarning
+    ? '1,000원 이상부터 충전이 가능해요'
+    : '1,000원 단위 충전만 가능해요';
+
   return (
     <St.ChargeWrapper>
       <St.ChargeInfoContainer>
@@ -67,9 +71,7 @@ const Charge = ({ setIsActiveNext, setChargeAmount }: ChargeProps) => {
           $isWarning={isWarning}
           autoFocus
         />
-        <St.ChargeWarningMsg $isWarning={isWarning}>
-          1,000원 단위 충전만 가능해요
-        </St.ChargeWarningMsg>
+        <St.ChargeWarningMsg $isWarning={isWarning}>{ERR_MSG_CONTENT}</St.ChargeWarningMsg>
       </St.ChargeInputContainer>
     </St.ChargeWrapper>
   );


### PR DESCRIPTION
## 🔥 Related Issues
resolved #issue_number

## 💜 작업 내용
- [x] 충전액 0원일 때도 예외처리에 포함
- [x] 충전액 0원일 때도 다음 cta 비활성화
- [x] 충전액 0원일 때는 경고 메시지 다르게

## ✅ PR Point
- 충전 금액을 0원 입력 혹은 입력 후 지우기로 미입력 해도 넘어가서 0원 충전 요청 되는 경우 예외처리
- 디자인 담당자와 상의 후 0원 입력 시에는 '1,000원 이상부터 충전이 가능해요' 메시지 띄워주기로 함
- 0원 입력시 경고 메시지를 다르게 띄워주기 위해서 즉, 0원인 예외 상황을 인지하기 위해 `isZeroWarning`이라는 플래그 만들어 사용

```ts
    if (removedCommaValue === 0) {
      //0원이면 경고 메시지
      setIsZeroWarning(true);
      setIsWarning(true);
      setIsActiveNext(false);
    } else if (removedCommaValue % 1000 === 0) {
      //1000원 단위인지 확인
      setIsZeroWarning(false);
      setIsWarning(false);
      setIsActiveNext(true);
    } else {
      //0원이 아닌데, 1000원 단위가 아닐 때 경고 메시지
      setIsZeroWarning(false);
      setIsWarning(true);
      setIsActiveNext(false);
    }
  };

  const ERR_MSG_CONTENT = isZeroWarning
    ? '1,000원 이상부터 충전이 가능해요'
    : '1,000원 단위 충전만 가능해요';
```


## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/eb0e29c1-f663-44e6-b189-9dc7bdd70ede

