### PR TITLE
[Custom:NoDesign] 동일 이미지 재첨부 안되는 문제 해결

### DIFF
--- a/src/components/Custom/NoDesign/Img/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesign/Img/CustomImgAttach.tsx
@@ -43,6 +43,7 @@ const CustomImgAttach = ({
       setPreviewURL(reader.result as string);
     }; // FileReader로 이미지 미리보기 구현
 
+    // 같은 파일을 올리면 change 이벤트 인지 못해서 여기서 초기화
     const dataTransfer = new DataTransfer();
     e.target.files = dataTransfer.files;
   };

--- a/src/components/Custom/NoDesign/Img/CustomImgAttach.tsx
+++ b/src/components/Custom/NoDesign/Img/CustomImgAttach.tsx
@@ -42,11 +42,14 @@ const CustomImgAttach = ({
     reader.onloadend = () => {
       setPreviewURL(reader.result as string);
     }; // FileReader로 이미지 미리보기 구현
-    // e.target.value = ''; // 같은 파일을 올리면 change 이벤트 인지 못해서 여기서 초기화
+
+    const dataTransfer = new DataTransfer();
+    e.target.files = dataTransfer.files;
   };
 
   const handleClickImgPreviewDelBtn = () => {
     setPreviewURL('');
+    setCustomImages(undefined);
   };
 
   return (

--- a/src/components/Custom/NoDesign/Img/CustomImgLayout.tsx
+++ b/src/components/Custom/NoDesign/Img/CustomImgLayout.tsx
@@ -8,13 +8,13 @@ import NoDesignFooter from '../NoDesignFooter';
 import Header from '../../../Header';
 import PageLayout from '../../../PageLayout';
 
-interface CustomImgPageProps {
+interface CustomImgLayoutProps {
   setStep: React.Dispatch<React.SetStateAction<number>>;
   customImages: FileList | undefined;
   setCustomImages: React.Dispatch<React.SetStateAction<FileList | undefined>>;
 }
 
-const CustomImgLayout = ({ setStep, customImages, setCustomImages }: CustomImgPageProps) => {
+const CustomImgLayout = ({ setStep, customImages, setCustomImages }: CustomImgLayoutProps) => {
   // const CUSTOM_VIEW_COUNT = 2;
 
   const [modalOn, setModalOn] = useState(false);

--- a/src/components/Custom/NoDesign/Request/CustomRequestLayout.tsx
+++ b/src/components/Custom/NoDesign/Request/CustomRequestLayout.tsx
@@ -8,7 +8,7 @@ import NoDesignFooter from '../NoDesignFooter';
 import Header from '../../../Header';
 import PageLayout from '../../../PageLayout';
 
-interface CustomRequestPageProps {
+interface CustomRequestLayoutProps {
   setStep: React.Dispatch<React.SetStateAction<number>>;
   name: string;
   setName: React.Dispatch<React.SetStateAction<string>>;
@@ -22,7 +22,7 @@ const CustomRequestLayout = ({
   setName,
   demand,
   setDemand,
-}: CustomRequestPageProps) => {
+}: CustomRequestLayoutProps) => {
   // const CUSTOM_VIEW_COUNT = 3;
 
   const [modalOn, setModalOn] = useState(false);


### PR DESCRIPTION
## 🔥 Related Issues
resolved #481 

## 💜 작업 내용
- [x] handler 함수에서 동일 이미지 초기화 안해줘서 재첨부 시 인식 못하는 로직 고치기
- [x] x 버튼 클릭 시 서버에 보낼 이미지도 초기화 시키기

## ✅ PR Point
- 커스텀 도안 이미지 통신 형식이 fileBlob -> FileList 자체로 바뀌면서 급하게 코드를 수정하느라 동일 이미지를 재첨부시 첨부가 안되는 문제를 해결 못했었습니다
- 동일 이미지를 다시 첨부시, ChageEvent에서 인식되지 못하는 문제가 있어 동일 이미지는 연속해서 첨부가 안돼 문제가 발생했습니다.
- 아마 지민언니 플로우에서도 같이 발생했던 문제라 참고하면 좋을것 같습니다 ~!

- 해결한 코드 
-> DataTransfer 객체가 반환하는 빈 FileList로 input이 들고 있는 FileList의 file들을 교체시킴 (빈 FileList로 초기화 시킴)
```ts
  const handleChangeImgAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
    const { files } = e.target;
    if (!files) return; // early return

    const fileBlob = files; // 서버 통신 시 보낼 타입
    setCustomImages(fileBlob);

    const reader = new FileReader();
    reader.readAsDataURL(fileBlob[0]);
    reader.onloadend = () => {
      setPreviewURL(reader.result as string);
    }; // FileReader로 이미지 미리보기 구현

    // 🚨 같은 파일을 올리면 change 이벤트 인지 못해서 여기서 초기화
    const dataTransfer = new DataTransfer();
    e.target.files = dataTransfer.files;
  };

// 🚨 X 버튼 클릭시 서버와 통신할 이미지 변수도 초기화 시킴
  const handleClickImgPreviewDelBtn = () => {
    setPreviewURL('');
    setCustomImages(undefined);
  };
```


## 😡 Trouble Shooting
- FileBlob의 경우 그냥 `e.target.value = ''`로 처리해주면 되지만, FileList 자체는 수정이 안되므로 어려움을 겪었습니다.
-> FileList를 반환하는 DataTransfer 객체를 사용하여 해결했습니당
-> DataTransfer 객체는 Drag and Drop API사용시 드롭되는 파일의 목록에 사용되는 객체로, Drag and Drop할 때 드래그되고 있는 data를 유지할 때 사용된다고 합니당


## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/d7f2d661-da82-4069-b45c-496a5e345c56



## 📚 Reference
- https://devlifetestcase.tistory.com/11
- https://velog.io/@kk95610/Spring-file-input%ED%83%9C%EA%B7%B8-%ED%95%98%EB%82%98%EB%A1%9C-%EC%97%AC%EB%9F%AC-%EB%B2%88-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%98%EA%B8%B0