### PR TITLE
List page/#474 2nd refactor

### DIFF
--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -43,6 +43,34 @@ const FilterBottom = ({
     data : 각 필터별 바텀시트의 내부 요소들 
   }
   */
+
+  // FILTER를 간소화한, 메타데이터의 틀을 만들어주는 함수
+  const filterMetaData = ({ index, tagData }: { index: number; tagData: string[] }) => ({
+    type: defaultName[index],
+    isOpen: isSheetOpen[index],
+    onClose: () => {
+      const newSheetOpen = [...isSheetOpen];
+      newSheetOpen[index] = false;
+      setSheetOpen(newSheetOpen);
+    },
+    onTap: (filter: boolean[]) => {
+      const newFilterTag = [...filterTag];
+      newFilterTag[index] = filter;
+      setFilterTag(newFilterTag);
+
+      const newSheetOpen = [...isSheetOpen];
+      newSheetOpen[index] = false;
+      setSheetOpen(newSheetOpen);
+
+      const trueIdx = filterTag[index].indexOf(true);
+
+      const newSelectedTag = [...selectedTag];
+      newSelectedTag[index] = FILTER[index].data[trueIdx];
+      setSelectedTag(newSelectedTag);
+    },
+    data: tagData,
+  });
+
   const FILTER = [
     {
       type: '정렬',

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -29,9 +29,15 @@ const FilterBottom = ({
   const { styleResponse } = useGetStyle();
 
   // 필터(바텀시트)의 각 태그명
-  const SORT_DATA = ['인기 순', '가격 낮은 순', '가격 높은 순'];
-  const GENRE_DATA = genreResponse.map((genre: GenreItemProps) => genre.name);
-  const STYLE_DATA = styleResponse.map((style: StyleItemProps) => style.name);
+  // 필터의 index로 접근하기 위해 하나의 배열로 묶기
+  // const SORT_DATA = ['인기 순', '가격 낮은 순', '가격 높은 순'];
+  // const GENRE_DATA = genreResponse.map((genre: GenreItemProps) => genre.name);
+  // const STYLE_DATA = styleResponse.map((style: StyleItemProps) => style.name);
+  const DATA = [
+    ['인기 순', '가격 낮은 순', '가격 높은 순'],
+    genreResponse.map((genre: GenreItemProps) => genre.name),
+    styleResponse.map((style: StyleItemProps) => style.name),
+  ];
 
   // 각 바텀시트의 메타데이터를 모아놓은 배열
   /*
@@ -73,9 +79,12 @@ const FilterBottom = ({
   });
 
   const FILTER = [
-    filterMetaData(SORT_INDEX, SORT_DATA),
-    filterMetaData(GENRE_INDEX, GENRE_DATA),
-    filterMetaData(STYLE_INDEX, STYLE_DATA),
+    // filterMetaData(SORT_INDEX, SORT_DATA),
+    // filterMetaData(GENRE_INDEX, GENRE_DATA),
+    // filterMetaData(STYLE_INDEX, STYLE_DATA),
+    filterMetaData(SORT_INDEX, DATA[SORT_INDEX]),
+    filterMetaData(GENRE_INDEX, DATA[GENRE_INDEX]),
+    filterMetaData(STYLE_INDEX, DATA[STYLE_INDEX]),
   ];
 
   // 바텀시트 내 각 태그 ref
@@ -87,9 +96,9 @@ const FilterBottom = ({
   // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
   // 추후 해당 배열 파괴 -> 각 숫자를 data.length로 변경 예정
   const [filterTag, setFilterTag] = useState([
-    new Array(SORT_DATA.length).fill(false),
-    new Array(GENRE_DATA.length).fill(false),
-    new Array(STYLE_DATA.length).fill(false),
+    new Array(DATA[SORT_INDEX].length).fill(false),
+    new Array(DATA[GENRE_INDEX].length).fill(false),
+    new Array(DATA[STYLE_INDEX].length).fill(false),
   ]);
 
   useEffect(() => {

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -5,7 +5,6 @@ import ic_check_small_light from '../../assets/icon/ic_check_small_light.svg';
 import ic_check_small_pink from '../../assets/icon/ic_check_small_pink.svg';
 import useGetGenre, { GenreItemProps } from '../../libs/hooks/list/useGetGenre';
 import useGetStyle, { StyleItemProps } from '../../libs/hooks/list/useGetStyle';
-import { LoDashImplicitNumberArrayWrapper } from 'lodash';
 
 interface FilterBottomProps {
   isSheetOpen: number;
@@ -57,18 +56,12 @@ const FilterBottom = ({
       const trueIdx = filterTag[index].indexOf(true);
 
       const newSelectedTag = [...selectedTag];
-      newSelectedTag[index] = FILTER[index].data[trueIdx];
+      newSelectedTag[index] = DATA[index][trueIdx];
       setSelectedTag(newSelectedTag);
     },
     // data: tagData,
     data: DATA[index],
   });
-
-  const FILTER = [
-    filterMetaData(SORT_INDEX),
-    filterMetaData(GENRE_INDEX),
-    filterMetaData(STYLE_INDEX),
-  ];
 
   // 바텀시트 내 각 태그 ref
   const tagRefs = useRef<HTMLParagraphElement[]>([]);
@@ -95,7 +88,7 @@ const FilterBottom = ({
   const handleClickTag = (tag: string, index: number, filterIdx: number) => {
     const newSelectedTag = [...selectedTag];
     if (selectedTag[filterIdx] === tag) {
-      newSelectedTag[filterIdx] = FILTER[filterIdx].type;
+      newSelectedTag[filterIdx] = filterMetaData(isSheetOpen).type;
     } else {
       newSelectedTag[filterIdx] = tag;
     }
@@ -124,11 +117,11 @@ const FilterBottom = ({
     onClose();
 
     const newTag = [...filterTag];
-    if (selectedTag[filterIdx] === FILTER[filterIdx].type) {
-      newTag[filterIdx] = FILTER[filterIdx].data.map(() => false);
+    if (selectedTag[filterIdx] === filterMetaData(filterIdx).type) {
+      newTag[filterIdx] = DATA[filterIdx].map(() => false);
     } else {
-      newTag[filterIdx] = FILTER[filterIdx].data.map((_, idx) => {
-        return idx === FILTER[filterIdx].data.indexOf(selectedTag[filterIdx]);
+      newTag[filterIdx] = DATA[filterIdx].map((_, idx) => {
+        return idx === DATA[filterIdx].indexOf(selectedTag[filterIdx]);
       });
     }
     setFilterTag(newTag);
@@ -140,23 +133,22 @@ const FilterBottom = ({
 
   return (
     <St.Wrapper>
-      {FILTER.map((filter, filterIdx) => (
+      {isSheetOpen !== -1 && (
         <CustomSheet
-          key={filter.type}
-          isOpen={filter.isOpen}
-          onClose={filter.onClose}
+          isOpen={filterMetaData(isSheetOpen).isOpen}
+          onClose={filterMetaData(isSheetOpen).onClose}
           detent='content-height'
           disableDrag={true}
         >
           <Sheet.Container>
             <Sheet.Header disableDrag={true} />
             <Sheet.Content>
-              {filter.data.map((el, idx) => (
+              {filterMetaData(isSheetOpen).data.map((el, idx) => (
                 <St.TagBox
                   key={idx}
-                  onClick={() => handleClickTag(el, idx, filterIdx)}
+                  onClick={() => handleClickTag(el, idx, isSheetOpen)}
                   ref={(refEl: HTMLParagraphElement) => (tagRefs.current[idx] = refEl)}
-                  className={filterTag[filterIdx][idx] ? 'checked' : ''}
+                  className={filterTag[isSheetOpen][idx] ? 'checked' : ''}
                 >
                   <span></span>
                   {el}
@@ -167,16 +159,18 @@ const FilterBottom = ({
               <St.Footer>
                 <St.Button
                   type='button'
-                  onClick={() => handleClickButton(filter.onClose, filterIdx)}
+                  onClick={() =>
+                    handleClickButton(filterMetaData(isSheetOpen).onClose, isSheetOpen)
+                  }
                 >
                   적용하기
                 </St.Button>
               </St.Footer>
             </Sheet.Content>
           </Sheet.Container>
-          <Sheet.Backdrop onTap={() => filter.onTap(filterTag[filterIdx])} />
+          <Sheet.Backdrop onTap={() => filterMetaData(isSheetOpen).onTap(filterTag[isSheetOpen])} />
         </CustomSheet>
-      ))}
+      )}
     </St.Wrapper>
   );
 };

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -152,14 +152,14 @@ const FilterBottom = ({
       // 선택된 태그에 대해서
       if (tagRefs.current.indexOf(el) === index) {
         // 클릭할 때마다 토글 구현
-        if (tagRefs.current[index].classList[STYLE_INDEX] === 'checked') {
+        if (tagRefs.current[index].classList.contains('checked')) {
           tagRefs.current[index].classList.remove('checked');
         } else {
           tagRefs.current[index].classList.add('checked');
         }
       } else {
         // 태그는 한개씩만 선택 가능하므로, 선택된 태그가 아닌 나머지는 remove
-        if (el.classList[STYLE_INDEX] === 'checked') {
+        if (el.classList.contains('checked')) {
           el.classList.remove('checked');
         }
       }

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -19,6 +19,10 @@ const FilterBottom = ({
   buttonName,
   setButtonName,
 }: FilterBottomProps) => {
+  const SORT_INDEX = 0;
+  const GENRE_INDEX = 1;
+  const STYLE_INDEX = 2;
+
   const { genreResponse } = useGetGenre();
   const { styleResponse } = useGetStyle();
 
@@ -38,75 +42,75 @@ const FilterBottom = ({
   const FILTER = [
     {
       type: '정렬',
-      isOpen: isSheetOpen[0],
+      isOpen: isSheetOpen[SORT_INDEX],
       onClose: () => {
         const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[0] = false;
+        newSheetOpen[SORT_INDEX] = false;
         setSheetOpen(newSheetOpen);
       },
       onTap: (filter: boolean[]) => {
         const newFilterTag = [...filterTag];
-        newFilterTag[0] = filter;
+        newFilterTag[SORT_INDEX] = filter;
         setFilterTag(newFilterTag);
 
         const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[0] = false;
+        newSheetOpen[SORT_INDEX] = false;
         setSheetOpen(newSheetOpen);
 
-        const trueIdx = filterTag[0].indexOf(true);
+        const trueIdx = filterTag[SORT_INDEX].indexOf(true);
 
         const newSelectedTag = [...selectedTag];
-        newSelectedTag[0] = FILTER[0].data[trueIdx];
+        newSelectedTag[SORT_INDEX] = FILTER[SORT_INDEX].data[trueIdx];
         setSelectedTag(newSelectedTag);
       },
       data: ['인기 순', '가격 낮은 순', '가격 높은 순'],
     },
     {
       type: '장르',
-      isOpen: isSheetOpen[1],
+      isOpen: isSheetOpen[GENRE_INDEX],
       onClose: () => {
         const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[1] = false;
+        newSheetOpen[GENRE_INDEX] = false;
         setSheetOpen(newSheetOpen);
       },
       onTap: (filter: boolean[]) => {
         const newFilterTag = [...filterTag];
-        newFilterTag[1] = filter;
+        newFilterTag[GENRE_INDEX] = filter;
         setFilterTag(newFilterTag);
 
         const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[1] = false;
+        newSheetOpen[GENRE_INDEX] = false;
         setSheetOpen(newSheetOpen);
 
-        const trueIdx = filterTag[1].indexOf(true);
+        const trueIdx = filterTag[GENRE_INDEX].indexOf(true);
 
         const newSelectedTag = [...selectedTag];
-        newSelectedTag[1] = genreData[trueIdx];
+        newSelectedTag[GENRE_INDEX] = genreData[trueIdx];
         setSelectedTag(newSelectedTag);
       },
       data: genreData,
     },
     {
       type: '스타일',
-      isOpen: isSheetOpen[2],
+      isOpen: isSheetOpen[STYLE_INDEX],
       onClose: () => {
         const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[2] = false;
+        newSheetOpen[STYLE_INDEX] = false;
         setSheetOpen(newSheetOpen);
       },
       onTap: (filter: boolean[]) => {
         const newFilterTag = [...filterTag];
-        newFilterTag[2] = filter;
+        newFilterTag[STYLE_INDEX] = filter;
         setFilterTag(newFilterTag);
 
         const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[2] = false;
+        newSheetOpen[STYLE_INDEX] = false;
         setSheetOpen(newSheetOpen);
 
-        const trueIdx = filterTag[2].indexOf(true);
+        const trueIdx = filterTag[STYLE_INDEX].indexOf(true);
 
         const newSelectedTag = [...selectedTag];
-        newSelectedTag[2] = styleData[trueIdx];
+        newSelectedTag[STYLE_INDEX] = styleData[trueIdx];
         setSelectedTag(newSelectedTag);
       },
       data: styleData,
@@ -128,9 +132,9 @@ const FilterBottom = ({
 
   useEffect(() => {
     const newFilterTag = [...filterTag];
-    newFilterTag[0] = [false, false, false];
-    newFilterTag[1] = genreResponse.map((item) => buttonName[1] === item.name);
-    newFilterTag[2] = styleResponse.map((item) => buttonName[2] === item.name);
+    newFilterTag[SORT_INDEX] = [false, false, false];
+    newFilterTag[GENRE_INDEX] = genreResponse.map((item) => buttonName[GENRE_INDEX] === item.name);
+    newFilterTag[STYLE_INDEX] = styleResponse.map((item) => buttonName[STYLE_INDEX] === item.name);
     setFilterTag(newFilterTag);
   }, [genreResponse, styleResponse]);
 
@@ -148,14 +152,14 @@ const FilterBottom = ({
       // 선택된 태그에 대해서
       if (tagRefs.current.indexOf(el) === index) {
         // 클릭할 때마다 토글 구현
-        if (tagRefs.current[index].classList[2] === 'checked') {
+        if (tagRefs.current[index].classList[STYLE_INDEX] === 'checked') {
           tagRefs.current[index].classList.remove('checked');
         } else {
           tagRefs.current[index].classList.add('checked');
         }
       } else {
         // 태그는 한개씩만 선택 가능하므로, 선택된 태그가 아닌 나머지는 remove
-        if (el.classList[2] === 'checked') {
+        if (el.classList[STYLE_INDEX] === 'checked') {
           el.classList.remove('checked');
         }
       }

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -68,6 +68,8 @@ const FilterBottom = ({
       setSelectedTag(newSelectedTag);
     },
     data: tagData,
+    // 여기에 추가한다면
+    // isTagSelected : new Array(tagData.length).fill(false) -> state가 안됨!
   });
 
   const FILTER = [
@@ -85,9 +87,9 @@ const FilterBottom = ({
   // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
   // 추후 해당 배열 파괴 -> 각 숫자를 data.length로 변경 예정
   const [filterTag, setFilterTag] = useState([
-    new Array(3).fill(false),
-    new Array(6).fill(false),
-    new Array(6).fill(false),
+    new Array(SORT_DATA.length).fill(false),
+    new Array(GENRE_DATA.length).fill(false),
+    new Array(STYLE_DATA.length).fill(false),
   ]);
 
   useEffect(() => {

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -11,6 +11,7 @@ interface FilterBottomProps {
   setSheetOpen: React.Dispatch<React.SetStateAction<boolean[]>>;
   buttonName: string[];
   setButtonName: React.Dispatch<React.SetStateAction<string[]>>;
+  defaultName: string[];
 }
 
 const FilterBottom = ({
@@ -18,6 +19,7 @@ const FilterBottom = ({
   setSheetOpen,
   buttonName,
   setButtonName,
+  defaultName,
 }: FilterBottomProps) => {
   const SORT_INDEX = 0;
   const GENRE_INDEX = 1;

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -5,6 +5,7 @@ import ic_check_small_light from '../../assets/icon/ic_check_small_light.svg';
 import ic_check_small_pink from '../../assets/icon/ic_check_small_pink.svg';
 import useGetGenre, { GenreItemProps } from '../../libs/hooks/list/useGetGenre';
 import useGetStyle, { StyleItemProps } from '../../libs/hooks/list/useGetStyle';
+import { LoDashImplicitNumberArrayWrapper } from 'lodash';
 
 interface FilterBottomProps {
   isSheetOpen: number;
@@ -36,19 +37,8 @@ const FilterBottom = ({
     styleResponse.map((style: StyleItemProps) => style.name),
   ];
 
-  // 각 바텀시트의 메타데이터를 모아놓은 배열
-  /*
-  {
-    type : 어떤 버튼인지 (정렬? 장르? 스타일?),
-    isOpen : 바텀시트 on/off를 다루는 state
-    onClose : 바텀시트를 off 시키는 state setter,
-    onTap : 바텀시트의 backdrop 터치 시 실행할 함수,
-    data : 각 필터별 바텀시트의 내부 요소들 
-  }
-  */
-
   // FILTER를 간소화한, 메타데이터의 틀을 만들어주는 함수
-  const filterMetaData = (index: number, tagData: string[]) => ({
+  const filterMetaData = (index: number) => ({
     type: defaultName[index],
     // isOpen -> boolean이어야함, 지금 열고자하는 필터가 맞는지 여부를 비교
     isOpen: isSheetOpen === index,
@@ -70,13 +60,14 @@ const FilterBottom = ({
       newSelectedTag[index] = FILTER[index].data[trueIdx];
       setSelectedTag(newSelectedTag);
     },
-    data: tagData,
+    // data: tagData,
+    data: DATA[index],
   });
 
   const FILTER = [
-    filterMetaData(SORT_INDEX, DATA[SORT_INDEX]),
-    filterMetaData(GENRE_INDEX, DATA[GENRE_INDEX]),
-    filterMetaData(STYLE_INDEX, DATA[STYLE_INDEX]),
+    filterMetaData(SORT_INDEX),
+    filterMetaData(GENRE_INDEX),
+    filterMetaData(STYLE_INDEX),
   ];
 
   // 바텀시트 내 각 태그 ref

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -35,6 +35,18 @@ const FilterBottom = ({
     genreResponse.map((genre: GenreItemProps) => genre.name),
     styleResponse.map((style: StyleItemProps) => style.name),
   ];
+  // 필터 버튼명(선택한 태그명)을 임시로 관리하는 state
+  const [selectedTag, setSelectedTag] = useState(buttonName);
+  // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
+  // 추후 해당 배열 파괴 -> 각 숫자를 data.length로 변경 예정
+  const [filterTag, setFilterTag] = useState([
+    new Array(DATA[SORT_INDEX].length).fill(false),
+    new Array(DATA[GENRE_INDEX].length).fill(false),
+    new Array(DATA[STYLE_INDEX].length).fill(false),
+  ]);
+
+  // 바텀시트 내 각 태그 ref
+  const tagRefs = useRef<HTMLParagraphElement[]>([]);
 
   // backdrop 클릭 시 바텀시트 꺼지는 함수
   const onTapBack = (filter: boolean[]) => {
@@ -51,28 +63,6 @@ const FilterBottom = ({
     setSelectedTag(newSelectedTag);
   };
 
-  // 바텀시트 내 각 태그 ref
-  const tagRefs = useRef<HTMLParagraphElement[]>([]);
-  // 필터 버튼명(선택한 태그명)을 임시로 관리하는 state
-  // buttonName을 건드릴 경우, 태그를 선택할 때마다 버튼명이 변경된다. 이를 방지하고, 임시 저장해뒀다가 바텀시트 내렸을 때 반응하기 위해 별도로 관리!
-  const [selectedTag, setSelectedTag] = useState(buttonName);
-
-  // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
-  // 추후 해당 배열 파괴 -> 각 숫자를 data.length로 변경 예정
-  const [filterTag, setFilterTag] = useState([
-    new Array(DATA[SORT_INDEX].length).fill(false),
-    new Array(DATA[GENRE_INDEX].length).fill(false),
-    new Array(DATA[STYLE_INDEX].length).fill(false),
-  ]);
-
-  useEffect(() => {
-    const newFilterTag = [...filterTag];
-    newFilterTag[SORT_INDEX] = [false, false, false];
-    newFilterTag[GENRE_INDEX] = genreResponse.map((item) => buttonName[GENRE_INDEX] === item.name);
-    newFilterTag[STYLE_INDEX] = styleResponse.map((item) => buttonName[STYLE_INDEX] === item.name);
-    setFilterTag(newFilterTag);
-  }, [genreResponse, styleResponse]);
-
   const handleClickTag = (tag: string, index: number, filterIdx: number) => {
     const newSelectedTag = [...selectedTag];
     if (selectedTag[filterIdx] === tag) {
@@ -84,16 +74,13 @@ const FilterBottom = ({
 
     tagRefs.current.forEach((el: HTMLParagraphElement) => {
       if (!el) return;
-      // 선택된 태그에 대해서
       if (tagRefs.current.indexOf(el) === index) {
-        // 클릭할 때마다 토글 구현
         if (tagRefs.current[index].classList.contains('checked')) {
           tagRefs.current[index].classList.remove('checked');
         } else {
           tagRefs.current[index].classList.add('checked');
         }
       } else {
-        // 태그는 한개씩만 선택 가능하므로, 선택된 태그가 아닌 나머지는 remove
         if (el.classList.contains('checked')) {
           el.classList.remove('checked');
         }
@@ -102,7 +89,7 @@ const FilterBottom = ({
   };
 
   const handleClickButton = (filterIdx: number) => {
-    setSheetOpen(-1); // 바텀시트 닫기
+    setSheetOpen(-1);
 
     const newTag = [...filterTag];
     if (selectedTag[filterIdx] === defaultName[isSheetOpen]) {
@@ -118,6 +105,14 @@ const FilterBottom = ({
     newButtonName[filterIdx] = selectedTag[filterIdx];
     setButtonName(newButtonName);
   };
+
+  useEffect(() => {
+    const newFilterTag = [...filterTag];
+    newFilterTag[SORT_INDEX] = [false, false, false];
+    newFilterTag[GENRE_INDEX] = genreResponse.map((item) => buttonName[GENRE_INDEX] === item.name);
+    newFilterTag[STYLE_INDEX] = styleResponse.map((item) => buttonName[STYLE_INDEX] === item.name);
+    setFilterTag(newFilterTag);
+  }, [genreResponse, styleResponse]);
 
   return (
     <St.Wrapper>

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -30,9 +30,6 @@ const FilterBottom = ({
 
   // 필터(바텀시트)의 각 태그명
   // 필터의 index로 접근하기 위해 하나의 배열로 묶기
-  // const SORT_DATA = ['인기 순', '가격 낮은 순', '가격 높은 순'];
-  // const GENRE_DATA = genreResponse.map((genre: GenreItemProps) => genre.name);
-  // const STYLE_DATA = styleResponse.map((style: StyleItemProps) => style.name);
   const DATA = [
     ['인기 순', '가격 낮은 순', '가격 높은 순'],
     genreResponse.map((genre: GenreItemProps) => genre.name),
@@ -74,14 +71,9 @@ const FilterBottom = ({
       setSelectedTag(newSelectedTag);
     },
     data: tagData,
-    // 여기에 추가한다면
-    // isTagSelected : new Array(tagData.length).fill(false) -> state가 안됨!
   });
 
   const FILTER = [
-    // filterMetaData(SORT_INDEX, SORT_DATA),
-    // filterMetaData(GENRE_INDEX, GENRE_DATA),
-    // filterMetaData(STYLE_INDEX, STYLE_DATA),
     filterMetaData(SORT_INDEX, DATA[SORT_INDEX]),
     filterMetaData(GENRE_INDEX, DATA[GENRE_INDEX]),
     filterMetaData(STYLE_INDEX, DATA[STYLE_INDEX]),

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -28,8 +28,10 @@ const FilterBottom = ({
   const { genreResponse } = useGetGenre();
   const { styleResponse } = useGetStyle();
 
-  const genreData = genreResponse.map((genre: GenreItemProps) => genre.name);
-  const styleData = styleResponse.map((style: StyleItemProps) => style.name);
+  // 필터(바텀시트)의 각 태그명
+  const SORT_DATA = ['인기 순', '가격 낮은 순', '가격 높은 순'];
+  const GENRE_DATA = genreResponse.map((genre: GenreItemProps) => genre.name);
+  const STYLE_DATA = styleResponse.map((style: StyleItemProps) => style.name);
 
   // 각 바텀시트의 메타데이터를 모아놓은 배열
   /*
@@ -65,7 +67,7 @@ const FilterBottom = ({
         newSelectedTag[SORT_INDEX] = FILTER[SORT_INDEX].data[trueIdx];
         setSelectedTag(newSelectedTag);
       },
-      data: ['인기 순', '가격 낮은 순', '가격 높은 순'],
+      data: SORT_DATA,
     },
     {
       type: '장르',
@@ -87,10 +89,10 @@ const FilterBottom = ({
         const trueIdx = filterTag[GENRE_INDEX].indexOf(true);
 
         const newSelectedTag = [...selectedTag];
-        newSelectedTag[GENRE_INDEX] = genreData[trueIdx];
+        newSelectedTag[GENRE_INDEX] = GENRE_DATA[trueIdx];
         setSelectedTag(newSelectedTag);
       },
-      data: genreData,
+      data: GENRE_DATA,
     },
     {
       type: '스타일',
@@ -112,10 +114,10 @@ const FilterBottom = ({
         const trueIdx = filterTag[STYLE_INDEX].indexOf(true);
 
         const newSelectedTag = [...selectedTag];
-        newSelectedTag[STYLE_INDEX] = styleData[trueIdx];
+        newSelectedTag[STYLE_INDEX] = STYLE_DATA[trueIdx];
         setSelectedTag(newSelectedTag);
       },
-      data: styleData,
+      data: STYLE_DATA,
     },
   ];
 

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -7,8 +7,8 @@ import useGetGenre, { GenreItemProps } from '../../libs/hooks/list/useGetGenre';
 import useGetStyle, { StyleItemProps } from '../../libs/hooks/list/useGetStyle';
 
 interface FilterBottomProps {
-  isSheetOpen: boolean[];
-  setSheetOpen: React.Dispatch<React.SetStateAction<boolean[]>>;
+  isSheetOpen: number;
+  setSheetOpen: React.Dispatch<React.SetStateAction<number>>;
   buttonName: string[];
   setButtonName: React.Dispatch<React.SetStateAction<string[]>>;
   defaultName: string[];
@@ -47,20 +47,19 @@ const FilterBottom = ({
   // FILTER를 간소화한, 메타데이터의 틀을 만들어주는 함수
   const filterMetaData = (index: number, tagData: string[]) => ({
     type: defaultName[index],
-    isOpen: isSheetOpen[index],
+    // isOpen -> boolean이어야함, 지금 열고자하는 필터가 맞는지 여부를 비교
+    isOpen: isSheetOpen === index,
     onClose: () => {
-      const newSheetOpen = [...isSheetOpen];
-      newSheetOpen[index] = false;
-      setSheetOpen(newSheetOpen);
+      // 바텀시트 닫는 부분
+      setSheetOpen(-1);
     },
     onTap: (filter: boolean[]) => {
       const newFilterTag = [...filterTag];
       newFilterTag[index] = filter;
       setFilterTag(newFilterTag);
 
-      const newSheetOpen = [...isSheetOpen];
-      newSheetOpen[index] = false;
-      setSheetOpen(newSheetOpen);
+      // 여기도 바텀시트 닫는 부분 (onClose와 동일)
+      setSheetOpen(-1);
 
       const trueIdx = filterTag[index].indexOf(true);
 

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -36,32 +36,20 @@ const FilterBottom = ({
     styleResponse.map((style: StyleItemProps) => style.name),
   ];
 
-  // FILTER를 간소화한, 메타데이터의 틀을 만들어주는 함수
-  const filterMetaData = (index: number) => ({
-    type: defaultName[index],
-    // isOpen -> boolean이어야함, 지금 열고자하는 필터가 맞는지 여부를 비교
-    isOpen: isSheetOpen === index,
-    onClose: () => {
-      // 바텀시트 닫는 부분
-      setSheetOpen(-1);
-    },
-    onTap: (filter: boolean[]) => {
-      const newFilterTag = [...filterTag];
-      newFilterTag[index] = filter;
-      setFilterTag(newFilterTag);
+  // backdrop 클릭 시 바텀시트 꺼지는 함수
+  const onTapBack = (filter: boolean[]) => {
+    const newFilterTag = [...filterTag];
+    newFilterTag[isSheetOpen] = filter;
+    setFilterTag(newFilterTag);
 
-      // 여기도 바텀시트 닫는 부분 (onClose와 동일)
-      setSheetOpen(-1);
+    setSheetOpen(-1);
 
-      const trueIdx = filterTag[index].indexOf(true);
+    const trueIdx = filterTag[isSheetOpen].indexOf(true);
 
-      const newSelectedTag = [...selectedTag];
-      newSelectedTag[index] = DATA[index][trueIdx];
-      setSelectedTag(newSelectedTag);
-    },
-    // data: tagData,
-    data: DATA[index],
-  });
+    const newSelectedTag = [...selectedTag];
+    newSelectedTag[isSheetOpen] = DATA[isSheetOpen][trueIdx];
+    setSelectedTag(newSelectedTag);
+  };
 
   // 바텀시트 내 각 태그 ref
   const tagRefs = useRef<HTMLParagraphElement[]>([]);
@@ -88,7 +76,7 @@ const FilterBottom = ({
   const handleClickTag = (tag: string, index: number, filterIdx: number) => {
     const newSelectedTag = [...selectedTag];
     if (selectedTag[filterIdx] === tag) {
-      newSelectedTag[filterIdx] = filterMetaData(isSheetOpen).type;
+      newSelectedTag[filterIdx] = defaultName[isSheetOpen];
     } else {
       newSelectedTag[filterIdx] = tag;
     }
@@ -113,11 +101,11 @@ const FilterBottom = ({
     });
   };
 
-  const handleClickButton = (onClose: () => void, filterIdx: number) => {
-    onClose();
+  const handleClickButton = (filterIdx: number) => {
+    setSheetOpen(-1); // 바텀시트 닫기
 
     const newTag = [...filterTag];
-    if (selectedTag[filterIdx] === filterMetaData(filterIdx).type) {
+    if (selectedTag[filterIdx] === defaultName[isSheetOpen]) {
       newTag[filterIdx] = DATA[filterIdx].map(() => false);
     } else {
       newTag[filterIdx] = DATA[filterIdx].map((_, idx) => {
@@ -135,15 +123,17 @@ const FilterBottom = ({
     <St.Wrapper>
       {isSheetOpen !== -1 && (
         <CustomSheet
-          isOpen={filterMetaData(isSheetOpen).isOpen}
-          onClose={filterMetaData(isSheetOpen).onClose}
+          isOpen={isSheetOpen !== -1}
+          onClose={() => {
+            setSheetOpen(-1);
+          }}
           detent='content-height'
           disableDrag={true}
         >
           <Sheet.Container>
             <Sheet.Header disableDrag={true} />
             <Sheet.Content>
-              {filterMetaData(isSheetOpen).data.map((el, idx) => (
+              {DATA[isSheetOpen].map((el, idx) => (
                 <St.TagBox
                   key={idx}
                   onClick={() => handleClickTag(el, idx, isSheetOpen)}
@@ -157,18 +147,13 @@ const FilterBottom = ({
               ))}
 
               <St.Footer>
-                <St.Button
-                  type='button'
-                  onClick={() =>
-                    handleClickButton(filterMetaData(isSheetOpen).onClose, isSheetOpen)
-                  }
-                >
+                <St.Button type='button' onClick={() => handleClickButton(isSheetOpen)}>
                   적용하기
                 </St.Button>
               </St.Footer>
             </Sheet.Content>
           </Sheet.Container>
-          <Sheet.Backdrop onTap={() => filterMetaData(isSheetOpen).onTap(filterTag[isSheetOpen])} />
+          <Sheet.Backdrop onTap={() => onTapBack(filterTag[isSheetOpen])} />
         </CustomSheet>
       )}
     </St.Wrapper>

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -45,7 +45,7 @@ const FilterBottom = ({
   */
 
   // FILTER를 간소화한, 메타데이터의 틀을 만들어주는 함수
-  const filterMetaData = ({ index, tagData }: { index: number; tagData: string[] }) => ({
+  const filterMetaData = (index: number, tagData: string[]) => ({
     type: defaultName[index],
     isOpen: isSheetOpen[index],
     onClose: () => {
@@ -72,81 +72,9 @@ const FilterBottom = ({
   });
 
   const FILTER = [
-    {
-      type: '정렬',
-      isOpen: isSheetOpen[SORT_INDEX],
-      onClose: () => {
-        const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[SORT_INDEX] = false;
-        setSheetOpen(newSheetOpen);
-      },
-      onTap: (filter: boolean[]) => {
-        const newFilterTag = [...filterTag];
-        newFilterTag[SORT_INDEX] = filter;
-        setFilterTag(newFilterTag);
-
-        const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[SORT_INDEX] = false;
-        setSheetOpen(newSheetOpen);
-
-        const trueIdx = filterTag[SORT_INDEX].indexOf(true);
-
-        const newSelectedTag = [...selectedTag];
-        newSelectedTag[SORT_INDEX] = FILTER[SORT_INDEX].data[trueIdx];
-        setSelectedTag(newSelectedTag);
-      },
-      data: SORT_DATA,
-    },
-    {
-      type: '장르',
-      isOpen: isSheetOpen[GENRE_INDEX],
-      onClose: () => {
-        const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[GENRE_INDEX] = false;
-        setSheetOpen(newSheetOpen);
-      },
-      onTap: (filter: boolean[]) => {
-        const newFilterTag = [...filterTag];
-        newFilterTag[GENRE_INDEX] = filter;
-        setFilterTag(newFilterTag);
-
-        const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[GENRE_INDEX] = false;
-        setSheetOpen(newSheetOpen);
-
-        const trueIdx = filterTag[GENRE_INDEX].indexOf(true);
-
-        const newSelectedTag = [...selectedTag];
-        newSelectedTag[GENRE_INDEX] = GENRE_DATA[trueIdx];
-        setSelectedTag(newSelectedTag);
-      },
-      data: GENRE_DATA,
-    },
-    {
-      type: '스타일',
-      isOpen: isSheetOpen[STYLE_INDEX],
-      onClose: () => {
-        const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[STYLE_INDEX] = false;
-        setSheetOpen(newSheetOpen);
-      },
-      onTap: (filter: boolean[]) => {
-        const newFilterTag = [...filterTag];
-        newFilterTag[STYLE_INDEX] = filter;
-        setFilterTag(newFilterTag);
-
-        const newSheetOpen = [...isSheetOpen];
-        newSheetOpen[STYLE_INDEX] = false;
-        setSheetOpen(newSheetOpen);
-
-        const trueIdx = filterTag[STYLE_INDEX].indexOf(true);
-
-        const newSelectedTag = [...selectedTag];
-        newSelectedTag[STYLE_INDEX] = STYLE_DATA[trueIdx];
-        setSelectedTag(newSelectedTag);
-      },
-      data: STYLE_DATA,
-    },
+    filterMetaData(SORT_INDEX, SORT_DATA),
+    filterMetaData(GENRE_INDEX, GENRE_DATA),
+    filterMetaData(STYLE_INDEX, STYLE_DATA),
   ];
 
   // 바텀시트 내 각 태그 ref
@@ -156,10 +84,11 @@ const FilterBottom = ({
   const [selectedTag, setSelectedTag] = useState(buttonName);
 
   // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
+  // 추후 해당 배열 파괴 -> 각 숫자를 data.length로 변경 예정
   const [filterTag, setFilterTag] = useState([
-    [false, false, false],
-    [false, false, false, false, false, false],
-    [false, false, false, false, false, false],
+    new Array(3).fill(false),
+    new Array(6).fill(false),
+    new Array(6).fill(false),
   ]);
 
   useEffect(() => {

--- a/src/components/List/FilterBottom.tsx
+++ b/src/components/List/FilterBottom.tsx
@@ -29,16 +29,12 @@ const FilterBottom = ({
   const { styleResponse } = useGetStyle();
 
   // 필터(바텀시트)의 각 태그명
-  // 필터의 index로 접근하기 위해 하나의 배열로 묶기
   const DATA = [
     ['인기 순', '가격 낮은 순', '가격 높은 순'],
     genreResponse.map((genre: GenreItemProps) => genre.name),
     styleResponse.map((style: StyleItemProps) => style.name),
   ];
-  // 필터 버튼명(선택한 태그명)을 임시로 관리하는 state
-  const [selectedTag, setSelectedTag] = useState(buttonName);
-  // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
-  // 추후 해당 배열 파괴 -> 각 숫자를 data.length로 변경 예정
+  const [selectedTag, setSelectedTag] = useState(buttonName); // 필터 버튼명(선택한 태그명)을 임시로 관리하는 state
   const [filterTag, setFilterTag] = useState([
     new Array(DATA[SORT_INDEX].length).fill(false),
     new Array(DATA[GENRE_INDEX].length).fill(false),

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -12,21 +12,21 @@ interface TattooListProps {
   isSheetOpen: boolean[];
   setSheetOpen: React.Dispatch<React.SetStateAction<boolean[]>>;
   buttonName: string[];
+  defaultName: string[];
 }
 
-const TattooList = ({ isSheetOpen, setSheetOpen, buttonName }: TattooListProps) => {
+const TattooList = ({ isSheetOpen, setSheetOpen, buttonName, defaultName }: TattooListProps) => {
   // 각 버튼의 선택 여부 (색이 바뀌어야하는 여부)를 저장하는 state
   const [selectedFilter, setSelectedFilter] = useState([false, false, false]);
 
   const navigate = useNavigate();
-  const DEFAULT_BUTTON_NAME = ['정렬', '장르', '스타일'];
 
   useEffect(() => {
     const newSelectedFilter = [...selectedFilter];
     buttonName.forEach((btn, idx) => {
-      if (btn !== DEFAULT_BUTTON_NAME[idx]) {
+      if (btn !== defaultName[idx]) {
         newSelectedFilter[idx] = true;
-      } else if (btn === DEFAULT_BUTTON_NAME[idx]) {
+      } else if (btn === defaultName[idx]) {
         newSelectedFilter[idx] = false;
       }
     });

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -9,13 +9,12 @@ import useGetAllList from '../../libs/hooks/list/useGetAllList';
 import { useNavigate } from 'react-router-dom';
 
 interface TattooListProps {
-  isSheetOpen: boolean[];
-  setSheetOpen: React.Dispatch<React.SetStateAction<boolean[]>>;
+  setSheetOpen: React.Dispatch<React.SetStateAction<number>>;
   buttonName: string[];
   defaultName: string[];
 }
 
-const TattooList = ({ isSheetOpen, setSheetOpen, buttonName, defaultName }: TattooListProps) => {
+const TattooList = ({ setSheetOpen, buttonName, defaultName }: TattooListProps) => {
   // 각 버튼의 선택 여부 (색이 바뀌어야하는 여부)를 저장하는 state
   const [selectedFilter, setSelectedFilter] = useState([false, false, false]);
 
@@ -48,9 +47,8 @@ const TattooList = ({ isSheetOpen, setSheetOpen, buttonName, defaultName }: Tatt
             key={el}
             $selected={selectedFilter[idx]}
             onClick={() => {
-              const newSheetOpen = [...isSheetOpen];
-              newSheetOpen[idx] = true;
-              setSheetOpen(newSheetOpen);
+              // 필터 버튼을 클릭하여 바텀시트를 켜는 부분
+              setSheetOpen(idx); // 어떤 필터 버튼을 클릭했는지에 따라 isSheetOpen 값이 0, 1, 2로 바뀜
             }}
           >
             {el}

--- a/src/components/Order/DeliveryInfo.tsx
+++ b/src/components/Order/DeliveryInfo.tsx
@@ -41,7 +41,6 @@ const DeliveryInfo = ({
             type='text'
             id='receiver'
             name='receiver'
-            placeholder='김타투'
             value={input}
             onChange={(e) => {
               setInput(e.target.value);
@@ -54,7 +53,6 @@ const DeliveryInfo = ({
             type='tel'
             id='phone'
             name='phone'
-            placeholder='010-0000-0000'
             maxLength={13}
             value={phone}
             onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e)} // 자동 하이픈

--- a/src/page/ListPage.tsx
+++ b/src/page/ListPage.tsx
@@ -18,7 +18,7 @@ const ListPage = () => {
   const name = state && (state as { name: string }).name;
 
   const DEFAULT_BUTTON_NAME = ['정렬', '장르', '스타일'];
-  const [isSheetOpen, setSheetOpen] = useState([false, false, false]);
+  const [isSheetOpen, setSheetOpen] = useState(-1); // -1이 바텀시트 off 상태
 
   // state && : 선택된 필터가 있을 경우
   // state.type이 장르일 때 버튼명을 state.name 값으로, 아니면 '장르'
@@ -48,7 +48,6 @@ const ListPage = () => {
       <HotCustom />
       <St.Line />
       <TattooList
-        isSheetOpen={isSheetOpen}
         setSheetOpen={setSheetOpen}
         buttonName={buttonName}
         defaultName={DEFAULT_BUTTON_NAME}

--- a/src/page/ListPage.tsx
+++ b/src/page/ListPage.tsx
@@ -17,6 +17,7 @@ const ListPage = () => {
   const type = state && (state as { type: string }).type;
   const name = state && (state as { name: string }).name;
 
+  const DEFAULT_BUTTON_NAME = ['정렬', '장르', '스타일'];
   const [isSheetOpen, setSheetOpen] = useState([false, false, false]);
 
   // state && : 선택된 필터가 있을 경우
@@ -46,12 +47,18 @@ const ListPage = () => {
     <PageLayout renderHeader={renderListPageHeader}>
       <HotCustom />
       <St.Line />
-      <TattooList isSheetOpen={isSheetOpen} setSheetOpen={setSheetOpen} buttonName={buttonName} />
+      <TattooList
+        isSheetOpen={isSheetOpen}
+        setSheetOpen={setSheetOpen}
+        buttonName={buttonName}
+        defaultName={DEFAULT_BUTTON_NAME}
+      />
       <FilterBottom
         isSheetOpen={isSheetOpen}
         setSheetOpen={setSheetOpen}
         buttonName={buttonName}
         setButtonName={setButtonName}
+        defaultName={DEFAULT_BUTTON_NAME}
       />
       <SideMenu isSideMenuOpen={isSideMenuOpen} setIsSideMenuOpen={setSideMenuOpen} />
     </PageLayout>

--- a/src/page/Order/CompletePage.tsx
+++ b/src/page/Order/CompletePage.tsx
@@ -17,17 +17,19 @@ const CompletePage = () => {
 
   return (
     <PageLayout renderHeader={renderCompletePageHeader} footer={<CompleteFooter />}>
-      <Result
-        mainText={'결제가 완료되었어요'}
-        description={'3일 내에 배송이 시작되며, 문자로 안내드려요'}
-      />
-      <St.Line />
-      <St.Title>주문 정보</St.Title>
-      <ProductInfo getOrderSheetStickerInfo={getOrderSheetStickerInfo} />
-      <St.LightLine />
-      <St.PriceContainer>
-        <PaymentMini getOrderAmountRes={getOrderAmountRes} />
-      </St.PriceContainer>
+      <St.Container>
+        <Result
+          mainText={'결제가 완료되었어요'}
+          description={'3일 내에 배송이 시작되며, 문자로 안내드려요'}
+        />
+        <St.Line />
+        <St.Title>주문 정보</St.Title>
+        <ProductInfo getOrderSheetStickerInfo={getOrderSheetStickerInfo} />
+        <St.LightLine />
+        <St.PriceContainer>
+          <PaymentMini getOrderAmountRes={getOrderAmountRes} />
+        </St.PriceContainer>
+      </St.Container>
     </PageLayout>
   );
 };
@@ -35,6 +37,9 @@ const CompletePage = () => {
 export default CompletePage;
 
 const St = {
+  Container: styled.section`
+    height: calc(100vh - 12.6rem);
+  `,
   Line: styled.hr`
     height: 1.3rem;
 

--- a/src/page/Order/OrderPage.tsx
+++ b/src/page/Order/OrderPage.tsx
@@ -29,12 +29,14 @@ const OrderPage = () => {
   const [isSheetOpen, setSheetOpen] = useState(false);
 
   const [isComplete, setComplete] = useState(false);
-  const [input, setInput] = useState<string>('');
-  const [phone, setPhone] = useState<string>('');
+  const [input, setInput] = useState<string>('기본값');
+  const [phone, setPhone] = useState<string>('010-0000-0000');
   const [address, setAddress] = useState<string>(''); // 우편번호
   const [firstAddress, setFirstAddress] = useState<string>(''); // 첫주소
   const [detailAddress, setDetailAddress] = useState<string>(''); // 세부주소
   const [agree, setAgree] = useState<boolean>(false);
+
+  console.log(response);
 
   const postData = {
     stickerId: state.stickerId,

--- a/src/page/Order/OrderPage.tsx
+++ b/src/page/Order/OrderPage.tsx
@@ -36,8 +36,6 @@ const OrderPage = () => {
   const [detailAddress, setDetailAddress] = useState<string>(''); // 세부주소
   const [agree, setAgree] = useState<boolean>(false);
 
-  console.log(response);
-
   const postData = {
     stickerId: state.stickerId,
     productCount: state.count,


### PR DESCRIPTION
## 🔥 Related Issues
resolved #474 

## 💜 작업 내용
- [x] 회원가입 이름, 주소 자동 설정 -> 서버에 부탁 
- [x] CompletePage Footer 붕붕 수정 
- [x] 바텀시트 3개 구현 방식을 하나로 간소화 
  - 버튼 클릭 시, type을 넘겨줘서 isSheetOpen <- type 값에 따라 
  - onTap, onClose 등 함수화해서 데이터 간소화 (property에서 제외) 
- [x] FILTER 배열 데이터 압축 
- [x] filterTag 초기값 삭제 & 해당 데이터 개선 방식 고민해보기 
- [x] 자주 사용하는 필터 인덱스 (0/1/2) 상수 데이터로 설정하기  
- [x] check 토글 구현 파트에서 classList[2]에 접근하지 말고 contains 메소드 사용하는 방식으로 수정 

## ✅ PR Point
> 그.. 리팩토링을 하나의 이슈로 파서.. 많은 태스크, 커밋을 한번에 묶은 바람에.. 자잘한 수정 사항 외에 굵직 굵직한 태스크만 리팩토링 실행한 과정에 따라 러프하게 정리했습니다 

## ✔️ Task1. CompletePage Footer 뜨는 문제

- 기존 : `sticky`로 고정 → 붕붕 뜸
    - 내가 나열한 컴포넌트를 감싸는 의문의 div가 있음 이 div가 화면세로를 꽉 채우지 않고, 애매하게 채우며, sticky footer는 그 div의 최하단에 위치해있기 때문에 함께 붕붕 뜨게 됨
    - **어디서 온 div인가!!!!  pageLayout발인 것 같은데, 그렇다면 다른 페이지 애들이 멀쩡한 이유는? 혹시 completePage가 내부 콘텐츠가 얼마 없어서 그런걸까?**

- `fixed`로 변경하면?
    - 최하단에 고정은 잘 됨 (붕붕 뜨는 문제 해결)
    - 데스크탑뷰로 봤을 때, min width가 먹히지 않아 버튼이 퍼져버리고
    - 콘텐츠가 화면을 가득 채우지 않는(스크롤X) completePage에서는 문제가 없지만, 다른 페이지 푸터를 fixed로 박아보면 내부에 있는 콘텐츠들과 무관하게 화면의 최하단에 박히기 때문에, **콘텐츠의 아래부분이 Footer에 가려져버리는 문제**가 발생한다.
- `absolute`로 변경하면?
    - 최하단에 고정은 되지만, **이상한 1px**이 생겨버린다. (하단 사진 참고)
    - <img width="472" alt="%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202023-08-11%20%EC%98%A4%EC%A0%84%201 34 25" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/2bed2412-3fb5-43a9-9893-74efb27c1e09">

### fixed와 sticky 차이 다시 공부

- fixed : 문서의 흐름에서 완전히 이탈한다. 따라서 스크롤에도 아무런 영향을 받지 않는다.
- sticky : 문서의 흐름에 따라 배치된다.
    - 스크롤되는 가장 가까운 상위 요소에 대해 offset이 적용된다.
    - 따라서 요소들이 컨테이너(화면)을 넘어가서 스크롤이 발생해도, 그 스크롤이 생기든 말든 상위 요소에 대해 딱 달라붙는다.
- ➡️ 가장 중요한 차이점은 **스크롤을** 했을 때
    - fixed는 스크롤의 영향을 아무것도 받지 않고, 그 자리에 고정되어있고
    - sticky는 스크롤 시 **기존 콘텐츠들의 흐름**에 따라 함께 움직인다. 그리고 타겟 요소를 만나게 될 때 딱! 달라붙는다
- 이해를 돕기 위해 구체적인 예시를 들어보자. 만약 Footer를 만들기 위해 `bottom 0`을 지정했다고 하자.
    - `fixed`일 경우, 어떠한 경우에도 화면의 아래에 footer가 박혀있다
    - `sticky`일 경우, 콘텐츠가 화면을 가득채우지 않으면(스크롤이 발생하지 않으면) 콘텐츠의 최하단에 footer가 위치한다.
    - 💥 반면 콘텐츠가 화면보다 넘쳐서 **스크롤이 발생**할 경우,
        - 스크롤을 할 때 **가장 아래의 요소에 도달하기 전까지**는 fixed와 동일하게 화면의 최하단에 박혀있지만,
        - 스크롤해서 **가장 아래에 도달했을 때**엔 **콘텐츠의 하단**에 footer가 딱 붙어서 콘텐츠와 한몸이 되어서 함께 스크롤이 된다.
    - 따라서 콘텐츠의 최하단에 도달한 후에 계속 억지로 스크롤을 발생시키면, fixed일 경우 영향을 받지 않지만, sticky footer의 경우 footer가 따라 위로 당겨 올려지게 된다.

### 리디아의 고민 과정

- fixed로 해결하자니… 기종에 따라 CompletePage가 약간의 스크롤이 생기는 기종도 있고, 아래가 텅텅 비는 기종도 있다. 또 스크롤이 생길 경우 footer 때문에 콘텐츠가 가려져서 안된다
- absolute로 해결하자니 위와 동일한 문제가 발생한다
- 💡 기존 방식인 sticky로 유지하면서, **콘텐츠의 높이를 억지로 늘려보자.**
    - 현재 header의 height가 5.6rem, footer의 height가 7rem
    - 내부 요소들을 div로 감싼 후, 해당 div의 height를 `calc(100vh-12.6rem)`으로 설정해주자.
    - 즉 **헤더와 푸터를 제외한 높이만큼 콘텐츠를 채우라**는 뜻

> 일단 해결. 근데 best는 아니어보임. 그리고 footer가 붕붕 뜨는게 맞는지 아직도 모르곘음. absolute 혹은 fixed로 전면 수정하고 그에 맞춰서 내부 contents들의 css들도 수정하는게 모범답안일 것 같다는 생각이 든다.
> 

---

## ✔️  Task2. 유저의 이름, 전화번호가 orderPage에서 자동 입력되도록

- placeholder 삭제
- value에 state가 들어있는 상황
- 해당 state의 default 값을 서버에서 받아온 사용자 이름, 전화번호로 세팅

---

## ✔️  Task3. FILTER 객체 배열 & 총 3개 렌더링되는 바텀시트 간소화

1. `DEFAULT_BUTTON_NAME`을 TattooList → ListPage로 이동 
    - ListPage → TattooList, FilterBottom으로 Props Drilling
2. 유사한 형태의 세 요소를 가지는 배열인 `FILTER` 데이터를 간소화 하고자, **필터의 index**와 **내부 태그 데이터**를 인수로 받아서 필터의 **메타데이터 객체**를 뽑아주는 리턴 함수 `filterMetaData` 생성 

```jsx
// FILTER를 간소화한, 메타데이터의 틀을 만들어주는 함수
const filterMetaData = (index: number, tagData: string[]) => ({
  type: defaultName[index],
  isOpen: isSheetOpen[index],
  onClose: () => {
    const newSheetOpen = [...isSheetOpen];
    newSheetOpen[index] = false;
    setSheetOpen(newSheetOpen);
  },
  onTap: (filter: boolean[]) => {
    const newFilterTag = [...filterTag];
    newFilterTag[index] = filter;
    setFilterTag(newFilterTag);

    const newSheetOpen = [...isSheetOpen];
    newSheetOpen[index] = false;
    setSheetOpen(newSheetOpen);

    const trueIdx = filterTag[index].indexOf(true);

    const newSelectedTag = [...selectedTag];
    newSelectedTag[index] = FILTER[index].data[trueIdx];
    setSelectedTag(newSelectedTag);
  },
  data: tagData,
});

const FILTER = [
    filterMetaData(SORT_INDEX, SORT_DATA),
    filterMetaData(GENRE_INDEX, GENRE_DATA),
    filterMetaData(STYLE_INDEX, STYLE_DATA),
  ];
```

3. 필터 내 각 태그의 선택 여부를 관리하는 이차원 배열인 filterTag를 간소화 해보자 
- 변경 전
    
    ```jsx
    // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
      const [filterTag, setFilterTag] = useState([
        [false, false, false],
        [false, false, false, false, false, false],
        [false, false, false, false, false, false],
      ]);
    ```
    
- 수정
    - `Array.prototype.fill` 메서드를 사용하여 동적으로 배열을 채울 수 있다.
    
    ```jsx
    const [filterTag, setFilterTag] = useState([
      new Array(SORT_DATA.length).fill(false),
      new Array(GENRE_DATA.length).fill(false),
      new Array(STYLE_DATA.length).fill(false),
    ]);
    ```
    

---

## ✔️  Task4. isSheetOpen의 값을 type index로 변경

기존에 state 배열의 요소 값은 boolean이었고, true/false 여부로 바텀시트 활성화 여부를 나타냈다. 

하지만 index (number형)으로 바꾸게 되면, 바텀시트 활성화 여부의 정의가 필요하다. 

- isSheetOpen이 `-1`일 때 → 바텀시트 **off**

다음은 isSheetOpen 값 변경으로 인해 잇따른 코드 수정 내용이다.  

1. state 선언부 수정 (ListPage.tsx)
    - 주석 : 변경 전 코드, 주석 아래 : 변경된 코드
    
    ```jsx
    // const [isSheetOpen, setSheetOpen] = useState([false, false, false]);
    const [isSheetOpen, setSheetOpen] = useState(-1); 
    ```
    
2. 필터 버튼 클릭하여 바텀시트 활성화하는 이벤트를 실행하는 부분 수정 (TattooList.tsx)
→ Task3의 간소화로 인해 `isSheetOpen`은 Props로 넘겨줄 필요가 아예 없어짐 
    - onClick 내부 로직 확인
    - 주석 : 변경 전 코드, 주석 아래 : 변경된 코드
    
    ```tsx
    
    {buttonName.map((el, idx) => (
        <St.FilterBtn
          key={el}
          $selected={selectedFilter[idx]}
          onClick={() => {
            // 필터 버튼을 클릭하여 바텀시트를 켜는 부분
            // const newSheetOpen = [...isSheetOpen];
            // newSheetOpen[idx] = true;
            // setSheetOpen(newSheetOpen);
            setSheetOpen(idx); // 어떤 필터 버튼을 클릭했는지에 따라 isSheetOpen 값이 0, 1, 2로 바뀜
          }}
        >
          {el}
          {selectedFilter[idx] ? <IcArrowBottomSmallLight /> : <IcArrowBottomSmallGray />}
        </St.FilterBtn>
      ))}
    ```
    
3. 바텀시트 관리 부분 수정 (FilterBottom.tsx)
    - 주석 : 변경 전 코드, 주석 아래 : 변경된 코드
        
        ```jsx
        
        const filterMetaData = (index: number, tagData: string[]) => ({
          type: defaultName[index],
          // isOpen: isSheetOpen[index],
          isOpen: isSheetOpen === index, // isOpen 값은 boolean이어야하므로 비교문 
          onClose: () => {
            // const newSheetOpen = [...isSheetOpen];
            // newSheetOpen[index] = false;
            // setSheetOpen(newSheetOpen);
            setSheetOpen(-1);
          },
          onTap: (filter: boolean[]) => {
            const newFilterTag = [...filterTag];
            newFilterTag[index] = filter;
            setFilterTag(newFilterTag);
        
            // const newSheetOpen = [...isSheetOpen];
            // newSheetOpen[index] = false;
            // setSheetOpen(newSheetOpen);
            setSheetOpen(-1);
        
            const trueIdx = filterTag[index].indexOf(true);
        
            const newSelectedTag = [...selectedTag];
            newSelectedTag[index] = FILTER[index].data[trueIdx];
            setSelectedTag(newSelectedTag);
          },
          data: tagData,
        });
        ```
        

---

## ✔️  Task5. 필터 내 태그 선택 여부 관리하는 filterTag 이차원 배열 파괴하고 다른 곳에 녹여넣어보기 (결론은 기존 방식을 유지하기로)

- 변경 전
    
    ```jsx
    // 필터 내 각 태그의 선택 여부를 관리하는 이차원배열 state ([정렬, 장르, 스타일])
    const [filterTag, setFilterTag] = useState([
      new Array(SORT_DATA.length).fill(false),
      new Array(GENRE_DATA.length).fill(false),
      new Array(STYLE_DATA.length).fill(false),
    ]);
    
    useEffect(() => {
      const newFilterTag = [...filterTag];
      newFilterTag[SORT_INDEX] = [false, false, false];
      newFilterTag[GENRE_INDEX] = genreResponse.map((item) => buttonName[GENRE_INDEX] === item.name);
      newFilterTag[STYLE_INDEX] = styleResponse.map((item) => buttonName[STYLE_INDEX] === item.name);
      setFilterTag(newFilterTag);
    }, [genreResponse, styleResponse]);
    ```
    
- filterTag state를 분해하고 관련 데이터를 뭉쳐놓기 위해  `filterMetadata` 마지막에
    
    `isTagSelected : new Array(tagData.length).fill(false)` 를 막연히 추가해보려했으나, 
    
    그렇게 되면 **state**로 관리가 안되기 때문에.. **기존 방식대로 별도의 useState를 선언해주는 수밖에** 
    
- 또, 코드 수 감축(요소값 변경을 위해 배열 복사하는 과정 삭제)을 위해 아래와 같은 방법으로 배열을 분해해보려고 했지만, 원래대로 **배열로 묶어서 관리**하는 방식을 유지하기로 함!
    
    ```jsx
    const [isSortTagSelected, setSortTagSelected] = useState(new Array(SORT_DATA.length).fill(false));
    const [isGenreTagSelected, setGenreTagSelected] = useState(new Array(GENRE_DATA.length).fill(false));
    const [isStyleTagSelected, setStyleTagSelected] = useState(new Array(STYLE_DATA.length).fill(false));
    ```
    
    왜냐하면 추상화를 해두면서 대부분 i**ndex(0, 1, 2)**를 통해 각 필터에 접근하는데, 저렇게 state를 분리시키면 그 방식으로 접근하기가 어렵기 때문에 index로 관리할 수 있도록 하나의 배열로 묶어주는게 맞는듯! 
    

---

## ✔️  Task6. 바텀시트 3개 모두 렌더링 → 필터 켤 때마다 필요한 바텀시트 하나씩만 렌더링

- 변경 전
    
    ```jsx
    const FILTER = [
      filterMetaData(SORT_INDEX, SORT_DATA),
      filterMetaData(GENRE_INDEX, GENRE_DATA),
      filterMetaData(STYLE_INDEX, STYLE_DATA),
    ];
    ```
    
    ```jsx
    {FILTER.map((filter, filterIdx) => (
      <CustomSheet
        key={filter.type}
        isOpen={filter.isOpen}
        onClose={filter.onClose}
        detent='content-height'
        disableDrag={true}
      >
        <Sheet.Container>
          <Sheet.Header disableDrag={true} />
          <Sheet.Content>
            {filter.data.map((el, idx) => (
              <St.TagBox
                key={idx}
                onClick={() => handleClickTag(el, idx, filterIdx)}
                ref={(refEl: HTMLParagraphElement) => (tagRefs.current[idx] = refEl)}
                className={filterTag[filterIdx][idx] ? 'checked' : ''}
              >
                <span></span>
                {el}
                <i></i>
              </St.TagBox>
            ))}
    
            <St.Footer>
              <St.Button
                type='button'
                onClick={() => handleClickButton(filter.onClose, filterIdx)}
              >
                적용하기
              </St.Button>
            </St.Footer>
          </Sheet.Content>
        </Sheet.Container>
        <Sheet.Backdrop onTap={() => filter.onTap(filterTag[filterIdx])} />
      </CustomSheet>
    ))}
    ```
    
    - FILTER에 **세개의 필터 데이터**가 들어있고, 렌더링 시 **FILTER를 순회**하면서 그 세가지 필터를 모두 만들어내는 로직이었음
- 변경
    - 렌더링 부분에서 FILTER.map 이 아니라, 하나의 `<CustomSheet>`만 렌더링하고, 필요한 정보는 **props**로 넘겨줘서 처리할 수 있도록 변경해야 함
    
- 변경 전 방식 :
    - `filterMetaData`라는 하나의 **데이터 객체가** 있음 (인자 : 필터index, 필터data)
    - `FILTER` 배열에서 `filterMetaData` 세 개를 요소로 가짐 (각 필터index와 필터data를 전달해서 메타데이터를 완성시킴)
    - 렌더링 시, `FILTER` **배열을 순회**하면서 각각에 **mapping되는 바텀시트를 세개** 찍어냄.
- 변경할 방식 :
    - `filterMetaData`라는 **하나의 데이터 객체**가 있음 (인자 : 필터index, 필터data)
    - 렌더링 시, `filterMetaData`를 바탕으로 바텀시트를 **하나** 찍어냄 (index, data 넘겨줘야함)
        - 내가 지금 어떤 필터 index를 선택했는지는 `isSheetOpen`의 값을 통해 알 수 있음
        - data도 index로 접근하기 위해서 분리돼있던 3개의 const를 하나의 **배열로 묶자**

- **변경할 방식대로 적용해보자!**
1. const data들을 하나의 배열로 묶기 
    - 변경 전
    
    ```jsx
    const SORT_DATA = ['인기 순', '가격 낮은 순', '가격 높은 순'];
    const GENRE_DATA = genreResponse.map((genre: GenreItemProps) => genre.name);
    const STYLE_DATA = styleResponse.map((style: StyleItemProps) => style.name);
    ```
    
    - 변경 후
    
    ```jsx
    const DATA = [
      ['인기 순', '가격 낮은 순', '가격 높은 순'],
      genreResponse.map((genre: GenreItemProps) => genre.name),
      styleResponse.map((style: StyleItemProps) => style.name)
    ];
    ```
    

1. DATA가 하나로 묶임에 따라 filterMetaData의 인자 두개 → 한개로 간소화 가능 (tagData 넘겨줄 필요 없음. index로 접근 가능하니까) 
    - 주석 : 변경 전, 주석 아래 : 변경 후
    
    ```jsx
    const DATA = [
      ['인기 순', '가격 낮은 순', '가격 높은 순'],
      genreResponse.map((genre: GenreItemProps) => genre.name),
      styleResponse.map((style: StyleItemProps) => style.name),
    ];
    
    const filterMetaData = (index: number) => ({
      // ...
      // data: tagData,
      data: DATA[index],
    });
    
    const FILTER = [
    	//filterMetaData(SORT_INDEX, DATA[SORT_INDEX]),
      filterMetaData(SORT_INDEX),
    	//filterMetaData(SORT_INDEX, DATA[GENRE_INDEX]),
      filterMetaData(GENRE_INDEX),
    	//filterMetaData(SORT_INDEX, DATA[STYLE_INDEX]),
      filterMetaData(STYLE_INDEX),
    ];
    ```
    

1. 렌더링부 `FILTER.map` → 하나의 `CustomSheet`로 바꾸기 
    - 변경 전
    
    ```jsx
    {FILTER.map((filter, filterIdx) => (
      <CustomSheet
        key={filter.type}
        isOpen={filter.isOpen}
        onClose={filter.onClose}
        detent='content-height'
        disableDrag={true}
      >
        <Sheet.Container>
          <Sheet.Header disableDrag={true} />
          <Sheet.Content>
            {filter.data.map((el, idx) => (
              <St.TagBox
                key={idx}
                onClick={() => handleClickTag(el, idx, filterIdx)}
                ref={(refEl: HTMLParagraphElement) => (tagRefs.current[idx] = refEl)}
                className={filterTag[filterIdx][idx] ? 'checked' : ''}
              >
                <span></span>
                {el}
                <i></i>
              </St.TagBox>
            ))}
    
            <St.Footer>
              <St.Button
                type='button'
                onClick={() => handleClickButton(filter.onClose, filterIdx)}
              >
                적용하기
              </St.Button>
            </St.Footer>
          </Sheet.Content>
        </Sheet.Container>
        <Sheet.Backdrop onTap={() => filter.onTap(filterTag[filterIdx])} />
      </CustomSheet>
    ))}
    ```
    
    - 변경 1차 시도 : 가장 바깥쪽의 [[FILTER.map](http://filter.map/)](http://FILTER.map) 껍데기만 벗겨냄
    
    ```jsx
    return (
        <St.Wrapper>
          <CustomSheet
            isOpen={filterMetaData(isSheetOpen).isOpen}
            onClose={filterMetaData(isSheetOpen).onClose}
            detent='content-height'
            disableDrag={true}
          >
            <Sheet.Container>
              <Sheet.Header disableDrag={true} />
              <Sheet.Content>
                {filterMetaData(isSheetOpen).data.map((el, idx) => (
                  <St.TagBox
                    key={idx}
                    onClick={() => handleClickTag(el, idx, isSheetOpen)}
                    ref={(refEl: HTMLParagraphElement) => (tagRefs.current[idx] = refEl)}
                    className={filterTag[isSheetOpen][idx] ? 'checked' : ''}
                  >
                    <span></span>
                    {el}
                    <i></i>
                  </St.TagBox>
                ))}
    
                <St.Footer>
                  <St.Button
                    type='button'
                    onClick={() => handleClickButton(filterMetaData(isSheetOpen).onClose, isSheetOpen)}
                  >
                    적용하기
                  </St.Button>
                </St.Footer>
              </Sheet.Content>
            </Sheet.Container>
            <Sheet.Backdrop onTap={() => filterMetaData(isSheetOpen).onTap(filterTag[isSheetOpen])} />
          </CustomSheet>
        </St.Wrapper>
      );
    ```
    
    - 🚨 이렇게 바꿨더니 **에러가 터짐**
        
    - <img width="528" alt="%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202023-08-17%20%EC%98%A4%EC%A0%84%202 12 07" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/135209a4-5d3a-4581-988b-98b2d7fd7048">

        
        - `filterMetaData(isSheetOpen).data` 가 undefined로 찍히는 문제.
        - 이유 : 아무런 바텀시트가 열려있지 않는 초기상태에선 `isSheetOpen`이 `-1`고, `DATA`엔 해당 **index에 접근할 수 없기 때문에** undefined가 뜬것.
        - 💡해결책 : 조건부 렌더링을 통해 `isSheetOpen`이 `-1`인 동안에는 바텀시트를 **아예 렌더링하지 않도록 만들어주자. →**  `isSheetOpen !== -1 &&`
    - **해결한 최종 코드**
        
        ```jsx
        
        return (
          <St.Wrapper>
            {isSheetOpen !== -1 && (
              <CustomSheet
                isOpen={filterMetaData(isSheetOpen).isOpen}
                onClose={filterMetaData(isSheetOpen).onClose}
                detent='content-height'
                disableDrag={true}
              >
                <Sheet.Container>
                  <Sheet.Header disableDrag={true} />
                  <Sheet.Content>
                    {filterMetaData(isSheetOpen).data.map((el, idx) => (
                      <St.TagBox
                        key={idx}
                        onClick={() => handleClickTag(el, idx, isSheetOpen)}
                        ref={(refEl: HTMLParagraphElement) => (tagRefs.current[idx] = refEl)}
                        className={filterTag[isSheetOpen][idx] ? 'checked' : ''}
                      >
                        <span></span>
                        {el}
                        <i></i>
                      </St.TagBox>
                    ))}
        
                    <St.Footer>
                      <St.Button
                        type='button'
                        onClick={() =>
                          handleClickButton(filterMetaData(isSheetOpen).onClose, isSheetOpen)
                        }
                      >
                        적용하기
                      </St.Button>
                    </St.Footer>
                  </Sheet.Content>
                </Sheet.Container>
                <Sheet.Backdrop onTap={() => filterMetaData(isSheetOpen).onTap(filterTag[isSheetOpen])} />
              </CustomSheet>
            )}
          </St.Wrapper>
        );
        ```
        
    
    ### 위의 작업을 해보고나니, 좀더 간소화할 수 있는 부분들이 보였다 !
    
    처음엔, `FILTER`라는 각 필터별 데이터를 담은 배열을 만들었기 때문에, 각 CustomSheet에 필요한 property들을 깔끔하게 **이름 붙여서** 사용하고자 **객체 배열의 형태**를 만든 것이었다. 
    
    ➡️ 그런데 세 개의 요소로 이루어진 배열 `FILTER`을 이제 안쓰고, **하나의 객체**(`filterMetaData`)**로 틀만 잡는 방식**으로 간소화를 하고나니, 심지어 인자도 두개가 아닌 하나로 줄어들고 나니, 객체로 묶은 아이들의 의미가 사라져버렸다. **객체 내에 있는 value들을 직접 customsheet에 적으면 그만이다.** 
    
    ### 즉!
    
    ```jsx
    const filterMetaData = (index: number) => ({
      type: defaultName[index],
      isOpen: isSheetOpen !== -1,
      onClose: () => {
        setSheetOpen(-1);
      },
      onTap: (filter: boolean[]) => {
        const newFilterTag = [...filterTag];
        newFilterTag[index] = filter;
        setFilterTag(newFilterTag);
        setSheetOpen(-1);
        const trueIdx = filterTag[index].indexOf(true);
        const newSelectedTag = [...selectedTag];
        newSelectedTag[index] = DATA[index][trueIdx];
        setSelectedTag(newSelectedTag);
      },
      data: DATA[index],
    });
    ```
    
    이렇게 정의돼있는데 각 key에 매칭되는 value들을 꺼내와서 렌더링부에서 
    
    - `filterMetaData(isSheetOpen).data` → `DATA[isSheetOpen]`
    - `filterMetaData(isSheetOpen).type` → `defaultName[isSheetOpen]`
    
    이런식으로 대체해주는게 낫지 않을까? 
    
    - 🚨 근데 isOpen은 빼면 `isSheetOpen === isSheetOpen` 가 되네,..?
    - 💡 → 이건 커스텀시트를 on/off 여부니까, 어떤 필터인지 몰라도 되지. (어차피 내부를 채우는건 다른 부분임.) 그니까 그냥 얘가 -1인지 아닌지만 알면 되니까 `isSheetOpen === index`가 아니라 `isSheetOpen ≠= -1`을 하면 될듯
    
    ### 그래서 최종적으로 수정한 방식은!
    
    - 주석 : **변경전, 주석 아래 : 변경 후**
    
    ```jsx
    // isOpen={filterMetaData(isSheetOpen).isOpen}
    isOpen={isSheetOpen !== -1}
    // onClose={filterMetaData(isSheetOpen).onClose}
    onClose={() => {setSheetOpen(-1);}}
    // {filterMetaData(isSheetOpen).data.map((el, idx) => ( ...
    {DATA[isSheetOpen].map((el, idx) => ( // ...
    // filterMetaData(isSheetOpen).type
    defaultName[isSheetOpen]
    // <Sheet.Backdrop onTap={() => filterMetaData(isSheetOpen).onTap(filterTag[isSheetOpen])} />
    <Sheet.Backdrop onTap={() => onTapBack(filterTag[isSheetOpen])} />
    ```
    
    - onTap에 필요한 코드는 여러 줄이기 때문에 별도의 함수 `onTapBack`을 정의해서 사용함
        
        ```jsx
        
        const onTapBack = (filter: boolean[]) => {
          const newFilterTag = [...filterTag];
          newFilterTag[isSheetOpen] = filter;
          setFilterTag(newFilterTag);
        
          setSheetOpen(-1);
        
          const trueIdx = filterTag[isSheetOpen].indexOf(true);
        
          const newSelectedTag = [...selectedTag];
          newSelectedTag[isSheetOpen] = DATA[isSheetOpen][trueIdx];
          setSelectedTag(newSelectedTag);
        };
        ```


## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지

## ☀️ 스크린샷 / GIF / 화면 녹화 

## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)