### PR TITLE
[List Page] 2차 QA

### DIFF
--- a/src/common/HotCustom.tsx
+++ b/src/common/HotCustom.tsx
@@ -49,7 +49,8 @@ const HotCustom = ({ isList }: { isList: boolean }) => {
                       {discountRate ? discountRate : 5}%
                     </St.HotCustomItemDiscountRate>
                     <St.HotCustomItemPrice>
-                      {discountPrice ? discountPrice.toLocaleString() : '4,000'}원
+                      {discountPrice ? discountPrice.toLocaleString() : '4,000'}
+                      <span>원</span>
                     </St.HotCustomItemPrice>
                   </St.HotCustomItemPriceWrapper>
                   <St.HotCustomItemOriginPrice>
@@ -176,6 +177,10 @@ const St = {
   `,
   HotCustomItemPrice: styled.p`
     ${({ theme }) => theme.fonts.title_extrabold_16};
+
+    & > span {
+      ${({ theme }) => theme.fonts.title_semibold_16};
+    }
   `,
   HotCustomItemOriginPrice: styled.span`
     margin-top: 0.1rem;

--- a/src/common/HotCustom.tsx
+++ b/src/common/HotCustom.tsx
@@ -18,7 +18,7 @@ const HotCustom = ({ isList }: { isList: boolean }) => {
   const { response, error, loading } = useGetHotCustom();
 
   return (
-    <St.HotCustomSection>
+    <>
       <St.Header>
         <St.HotCustomButton type='button' onClick={handleClickHotCustom}>
           <St.HotCustomTitle>HOT CUSTOM</St.HotCustomTitle>
@@ -60,15 +60,12 @@ const HotCustom = ({ isList }: { isList: boolean }) => {
             })}
         </ScrollContainer>
       </St.HotCustomWrapper>
-    </St.HotCustomSection>
+    </>
   );
 };
 
 const St = {
-  HotCustomSection: styled.section`
-    padding-left: 2rem;
-  `,
-
+  // HotCustomSection padding-left 삭제로, 스타일컴포넌트 아예 삭제
   Header: styled.header`
     display: flex;
     justify-content: start;
@@ -90,6 +87,8 @@ const St = {
   `,
 
   HotCustomTitle: styled.h2`
+    margin-left: 2rem;
+
     ${({ theme }) => theme.fonts.title_eng_bold_20};
     color: ${({ theme }) => theme.colors.gray8};
   `,
@@ -104,7 +103,6 @@ const St = {
     flex-direction: row;
     gap: 1.2rem;
     justify-content: space-between;
-    margin-right: 1.2rem;
 
     .scroll-container {
       display: flex;
@@ -113,6 +111,8 @@ const St = {
 
       height: 28rem;
       width: 100%;
+
+      padding: 0rem 2rem;
     }
   `,
 

--- a/src/common/HotCustom.tsx
+++ b/src/common/HotCustom.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { IcArrowRightDark, LabelCustomSmall } from '../assets/icon';
 import useGetHotCustom from '../libs/hooks/useGetHotCustom';
 
-const HotCustom = () => {
+const HotCustom = ({ isList }: { isList: boolean }) => {
   const navigate = useNavigate();
 
   const handleClickHotCustom = () => {
@@ -22,7 +22,7 @@ const HotCustom = () => {
       <St.Header>
         <St.HotCustomButton type='button' onClick={handleClickHotCustom}>
           <St.HotCustomTitle>HOT CUSTOM</St.HotCustomTitle>
-          <IcArrowRightDark />
+          {!isList && <IcArrowRightDark />}
         </St.HotCustomButton>
       </St.Header>
       <St.HotCustomWrapper>

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -56,7 +56,9 @@ const TattooList = ({ setSheetOpen, buttonName, defaultName }: TattooListProps) 
           </St.FilterBtn>
         ))}
       </St.BtnContainer>
-      <St.CountText>전체 {response.length}개</St.CountText>
+      <St.CountText>
+        전체 <span>{response.length}</span>개
+      </St.CountText>
       <St.CardContainer>
         {!loading &&
           !error &&
@@ -115,6 +117,10 @@ const St = {
     margin: 2.8rem 0rem 1.6rem 2.2rem;
     color: ${({ theme }) => theme.colors.gray4};
     ${({ theme }) => theme.fonts.body_medium_14};
+
+    & > span {
+      ${({ theme }) => theme.fonts.body_semibold_14};
+    }
   `,
   CardContainer: styled.section`
     display: grid;

--- a/src/components/List/TattooList.tsx
+++ b/src/components/List/TattooList.tsx
@@ -72,7 +72,10 @@ const TattooList = ({ setSheetOpen, buttonName, defaultName }: TattooListProps) 
                 <h2>{name}</h2>
                 <div>
                   <St.CardDiscount>{discountRate}%</St.CardDiscount>
-                  <St.CardPrice>{discountPrice && discountPrice.toLocaleString()}원</St.CardPrice>
+                  <St.CardPrice>
+                    {discountPrice && discountPrice.toLocaleString()}
+                    <span>원</span>
+                  </St.CardPrice>
                 </div>
                 <p>{price.toLocaleString()}원</p>
               </St.Card>
@@ -135,7 +138,7 @@ const St = {
     & > h2 {
       margin: 1.5rem 0rem 0rem 2rem;
       color: ${({ theme }) => theme.colors.gray7};
-      ${({ theme }) => theme.fonts.title_semibold_16};
+      ${({ theme }) => theme.fonts.body_medium_16};
     }
 
     & > p {
@@ -178,5 +181,9 @@ const St = {
 
     color: ${({ theme }) => theme.colors.gray7};
     ${({ theme }) => theme.fonts.title_extrabold_16};
+
+    & > span {
+      ${({ theme }) => theme.fonts.title_semibold_16};
+    }
   `,
 };

--- a/src/page/ListPage.tsx
+++ b/src/page/ListPage.tsx
@@ -45,7 +45,7 @@ const ListPage = () => {
 
   return (
     <PageLayout renderHeader={renderListPageHeader}>
-      <HotCustom />
+      <HotCustom isList={true} />
       <St.Line />
       <TattooList
         setSheetOpen={setSheetOpen}

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -69,7 +69,7 @@ const MainPage = () => {
     >
       {isWelcomeModalOpen && <WelcomeModal setModalOn={setIsWelcomeModalOpen} />}
       <MainBanner />
-      <HotCustom />
+      <HotCustom isList={false} />
       <MainEventBanner setToast={setToast} />
       <MainTheme />
       <MainStyle />


### PR DESCRIPTION
## 🔥 Related Issues
resolved #491 

## 💜 작업 내용
![Slide 16_9 - 12](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/f658d5df-08c2-46e6-8499-c8a200469b61)
![Slide 16_9 - 13](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/97cda523-8854-40fa-ad92-30b5825cb5d4)


## ✅ PR Point
1. 화살표 버튼 삭제 
    - HotCustom 컴포넌트에 prop 추가 isList
        - isList : 메인화면에서 왔으면 false, ListPage에서 왔으면 true
        - isList에 따라 헤더 화살표 조건부 렌더링
2. HOT CUSTOM 리스트 양옆 여백 조정 
    - 변경 전 : 스크롤과 부관하게 좌우 여백 있음
    - 변경
        - 최상단 section 자체에 있는 margin/padding 들 삭제
        - 최상단 section 삭제했더니 HOT CUSTOM 헤더 margin도 사라져서 별도로 넣어줌
        - list 내용물 양옆에 padding 추가 (스크롤의 시작과 끝에 여백 생기도록)
3. 각종 글자 볼드 변경 
    - 핫커스텀 ‘원’ 볼드 빼고
    - 전체 개수 볼드 추가
