### PR TITLE
[DetailPage] 2차 QA

### DIFF
--- a/src/common/CustomScrollContainer.tsx
+++ b/src/common/CustomScrollContainer.tsx
@@ -1,5 +1,7 @@
 import ScrollContainer from 'react-indiana-drag-scroll';
 import { styled } from 'styled-components';
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const CustomScrollContainer = ({
   title,
@@ -8,6 +10,14 @@ const CustomScrollContainer = ({
   title: string;
   children: React.ReactNode;
 }) => {
+  const { pathname } = useLocation();
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.scrollTo(0, 0);
+  }, [pathname]);
+
   return (
     <>
       <St.CustomScrollWrapper>
@@ -15,7 +25,9 @@ const CustomScrollContainer = ({
           <St.CustomScrollTitle>{title}</St.CustomScrollTitle>
         </St.CustomScrollHeader>
         <St.CustomScrollItemWrapper>
-          <ScrollContainer className='scroll-container'>{children}</ScrollContainer>
+          <ScrollContainer innerRef={ref} className='scroll-container'>
+            {children}
+          </ScrollContainer>
         </St.CustomScrollItemWrapper>
       </St.CustomScrollWrapper>
     </>

--- a/src/common/CustomScrollContainer.tsx
+++ b/src/common/CustomScrollContainer.tsx
@@ -24,12 +24,11 @@ const CustomScrollContainer = ({
 
 const St = {
   CustomScrollWrapper: styled.section`
-    padding-left: 2rem;
-
     background-color: ${({ theme }) => theme.colors.white};
   `,
 
   CustomScrollHeader: styled.header`
+    margin-left: 2.2rem;
     display: flex;
   `,
 
@@ -42,11 +41,12 @@ const St = {
     gap: 1.2rem;
     justify-content: space-between;
     margin-top: 2.2rem;
-    margin-right: 1.2rem;
 
     .scroll-container {
       display: flex;
-      gap: 1.2rem;
+      gap: 1rem;
+
+      padding: 0rem 2rem;
 
       height: 23.3rem;
       width: 100%;

--- a/src/common/CustomScrollContainer.tsx
+++ b/src/common/CustomScrollContainer.tsx
@@ -34,7 +34,7 @@ const St = {
   `,
 
   CustomScrollTitle: styled.h2`
-    ${({ theme }) => theme.fonts.title_eng_bold_18};
+    ${({ theme }) => theme.fonts.title_semibold_16};
   `,
 
   CustomScrollItemWrapper: styled.div`

--- a/src/common/SmallTattooCard.tsx
+++ b/src/common/SmallTattooCard.tsx
@@ -32,7 +32,10 @@ const SmallTattooCard = ({
       <St.SmallTattooCardTitle>{title}</St.SmallTattooCardTitle>
       <St.SmallTattooCardPriceTextWrapper>
         <St.SmallTattooCardDiscountRate>{discountRate}%</St.SmallTattooCardDiscountRate>
-        <St.SmallTattooCardPriceText>{price.toLocaleString()}원</St.SmallTattooCardPriceText>
+        <St.SmallTattooCardPriceText>
+          {price.toLocaleString()}
+          <span>원</span>
+        </St.SmallTattooCardPriceText>
       </St.SmallTattooCardPriceTextWrapper>
       <St.SmallTattooCardOriginalPriceText>
         {originalPrice.toLocaleString()}원
@@ -78,6 +81,10 @@ const St = {
 
     ${({ theme }) => theme.fonts.title_extrabold_16};
     color: ${({ theme }) => theme.colors.gray7};
+
+    & > span {
+      ${({ theme }) => theme.fonts.title_semibold_16};
+    }
   `,
 
   SmallTattooCardOriginalPriceText: styled.p`

--- a/src/common/SmallTattooCard.tsx
+++ b/src/common/SmallTattooCard.tsx
@@ -69,6 +69,8 @@ const St = {
 
   SmallTattooCardPriceTextWrapper: styled.div`
     display: flex;
+
+    margin-top: 0.3rem;
   `,
 
   SmallTattooCardDiscountRate: styled.p`

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -142,6 +142,10 @@ const St = {
     background-color: ${({ theme }) => theme.colors.gray5};
   `,
   Like: styled.button`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     width: 7rem;
     height: 7rem;
   `,

--- a/src/components/Detail/DetailInfo.tsx
+++ b/src/components/Detail/DetailInfo.tsx
@@ -127,11 +127,11 @@ const St = {
 
     & > span:nth-child(odd) {
       ${({ theme }) => theme.fonts.body_medium_14};
-      color: ${({ theme }) => theme.colors.gray4};
+      color: ${({ theme }) => theme.colors.gray3};
     }
     & > span:nth-child(even) {
       ${({ theme }) => theme.fonts.body_medium_14};
-      color: ${({ theme }) => theme.colors.gray3};
+      color: ${({ theme }) => theme.colors.gray4};
     }
   `,
   BoldLine: styled.hr`

--- a/src/components/Detail/DetailInfo.tsx
+++ b/src/components/Detail/DetailInfo.tsx
@@ -1,10 +1,7 @@
 import styled from 'styled-components';
-import { useState } from 'react';
 import { StickerItemProps } from '../../libs/hooks/detail/useGetSticker';
 
 const DetailInfo = ({ response }: { response: StickerItemProps }) => {
-  const [isOpen, setOpen] = useState(false);
-
   const {
     name,
     discountRate,
@@ -46,21 +43,7 @@ const DetailInfo = ({ response }: { response: StickerItemProps }) => {
         {stickerThemes && stickerThemes.map((el: string) => <St.Tag key={el}>{el}</St.Tag>)}
         {stickerStyles && stickerStyles.map((el: string) => <St.Tag key={el}>{el}</St.Tag>)}
       </St.TagContainer>
-      {description && (
-        <p>
-          <St.DetailText>{description.substring(0, 60)}</St.DetailText>
-          {isOpen ? (
-            <St.DetailText>{description.substring(61)}</St.DetailText>
-          ) : (
-            description.length > 61 && (
-              <St.DetailText>
-                {'···'}
-                <St.Button onClick={() => setOpen(true)}>더보기</St.Button>
-              </St.DetailText>
-            )
-          )}
-        </p>
-      )}
+      <St.DetailText>{description}</St.DetailText>
       <St.BoldLine />
     </St.Wrapper>
   );
@@ -159,10 +142,5 @@ const St = {
   DetailText: styled.span`
     ${({ theme }) => theme.fonts.body_medium_14};
     color: ${({ theme }) => theme.colors.gray4};
-  `,
-  Button: styled.button`
-    display: inline;
-    ${({ theme }) => theme.fonts.body_underline_medium_14};
-    color: ${({ theme }) => theme.colors.gray5};
   `,
 };

--- a/src/libs/hooks/detail/useGetRelated.tsx
+++ b/src/libs/hooks/detail/useGetRelated.tsx
@@ -42,7 +42,7 @@ const useGetRelated = (id: number) => {
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [id]);
 
   return { response, error, loading };
 };

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -68,9 +68,11 @@ const DetailPage = () => {
           <DetailInfo response={response} />
         </>
       )}
-      {!relatedError && !relatedLoading && relatedResponse && (
-        <CustomScrollContainer title='비슷한 제품도 추천드려요'>
-          {relatedResponse.map((el) => (
+      <CustomScrollContainer title='비슷한 제품도 추천드려요'>
+        {!relatedError &&
+          !relatedLoading &&
+          relatedResponse &&
+          relatedResponse.map((el) => (
             <SmallTattooCard
               key={el.id}
               id={el.id}
@@ -82,8 +84,7 @@ const DetailPage = () => {
               isCustom={el.isCustom}
             />
           ))}
-        </CustomScrollContainer>
-      )}
+      </CustomScrollContainer>
       {!error && !loading && response && (
         <DetailBottom
           id={Number(id)}

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -7,29 +7,35 @@ import { useEffect, useState } from 'react';
 import DetailBottom from '../components/Detail/DetailBottom';
 import CustomScrollContainer from '../common/CustomScrollContainer';
 import SmallTattooCard from '../common/SmallTattooCard';
-import BackBtn from '../common/Header/BackBtn';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import useGetSticker from '../libs/hooks/detail/useGetSticker';
 import useGetRelated from '../libs/hooks/detail/useGetRelated';
+import { IcBackDark } from '../assets/icon';
 
 const DetailPage = () => {
+  const navigate = useNavigate();
   const { id } = useParams();
-  // param.id로 서버에서 상품 데이터 get 해오기
 
-  //const navigate = useNavigate();
   const [isSheetOpen, setSheetOpen] = useState(false);
 
-  // 찜 여부 state -> 추후 서버통신
   const [like, setLike] = useState<boolean | null>(false);
 
   const renderDetailPageHeader = () => {
-    return <Header leftSection={<BackBtn />} />;
+    return (
+      <Header
+        leftSection={
+          <IcBackDark
+            onClick={() => {
+              navigate('/list');
+            }}
+          />
+        }
+      />
+    );
   };
 
-  // 상세페이지 정보 서버 통신
   const { response, error, loading } = useGetSticker(Number(id));
 
-  // 비슷한 목록 서버 통신
   const {
     response: relatedResponse,
     error: relatedError,

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -68,10 +68,9 @@ const DetailPage = () => {
           <DetailInfo response={response} />
         </>
       )}
-      <CustomScrollContainer title='비슷한 제품도 추천드려요'>
-        {!relatedError &&
-          !relatedLoading &&
-          relatedResponse.map((el) => (
+      {!relatedError && !relatedLoading && relatedResponse && (
+        <CustomScrollContainer title='비슷한 제품도 추천드려요'>
+          {relatedResponse.map((el) => (
             <SmallTattooCard
               key={el.id}
               id={el.id}
@@ -83,7 +82,8 @@ const DetailPage = () => {
               isCustom={el.isCustom}
             />
           ))}
-      </CustomScrollContainer>
+        </CustomScrollContainer>
+      )}
       {!error && !loading && response && (
         <DetailBottom
           id={Number(id)}


### PR DESCRIPTION
## 🔥 Related Issues
resolved #492 

## 💜 작업 내용
![Slide 16_9 - 14](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/e017db47-e9b8-4db7-9315-515d138a669e)
![Slide 16_9 - 15](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/ece74dc6-9c60-47c8-a2d9-17ff24180525)
![Slide 16_9 - 16](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/43843ead-0783-4e31-9808-13ef65e5536d)


## ✅ PR Point
- 각종 폰트, 굵기, 색상, 정렬, 여백 수정 모두 완료 ✅
- 회색 박스 하단 영역 차이 -> 반영 안함 ❌
  현재 우리 서비스는 상품당 사진이 한장 뿐이라서 하단 indicator(pagination 동글뱅이)가 자동으로 빠짐. 그래서 indicator 자리만큼 하단 회색 영역의 높이가 줄어든것. 근데 indicator 없는 경우에도(한 장인 경우에도) 회색 영역 높이를 맞추면 해당 이미지처럼 위아래 간격이 안맞아서 사진이 가운데 정렬이 안된 것처럼 붕붕 떠버림! -> 이 내용 규태한테 전달했고 디팟과 논의해본다고 함 
- 더보기 기능 삭제하기로 해서 삭제함 ✅

### 💡주요 : 비슷한 제품 추천 관련 QA사항들 
- 비슷한 제품 추천에서 제품 클릭해서 이동할 경우, 뒤로가기를 눌렀을 때 이전 제품 상세페이지로 이동하는 문제 -> 상세페이지가 아닌 **목록 페이지로 이동**해야함 (계속해서 비슷한추천제품 타고 들어갈 경우 뒤로가기 depth가 무한히 깊어지기 때문에) 
  - BackBtn에 `navigate('/list')` 달아서 해결 

- 추천아이템 하나 눌렀을 때 비슷한 추천 리스트가 반영(리렌더링)이 안됨
    - relatedResponse를 mapping 해서 제품카드를 만드니까 **서버에서 불러온 relatedResponse 값**이 제대로 update되지 않는 것으로 보임
        - **useGetRelated 통신**이 잘 안된 것으로 보임
    - 비슷한 제품 추천 리스트 외에 **제품의 상세 정보는 잘 렌더링** 되는데, 둘이 똑같은 시점에 똑같은 방식으로 서버통신을 하고 있다.
    - ➡️ 따라서 세부 정보를 불러오는 커스텀훅인 `useGetSticker`과 비슷한제품추천 리스트를 불러오는 커스텀훅인 `useGetRelated`를 **비교**해보았다.
    - 차이는 아래에서 발견되었다
        
        ```jsx
        // useGetSticker
        useEffect(() => {
            fetchData();
          }, [id]);
        
        // useGetRelated
        useEffect(() => {
            fetchData();
          }, []);
        ```
        
        서버 통신을 실행하는 **useEffect의 의존성배열에 id가 누락**되어있었고, 따라서 비슷한 추천제품을 클릭하여 /detail/{id}로 navigate 하더라도 서버 통신이 최초 실행된 적이 있기 때문에 새로고침하는 케이스 외엔 더이상 호출되지 않았던 것이다. 
        
    
    ```jsx
    // useGetRelated
    useEffect(() => {
      fetchData();
    }, [id]);
    ```
    
    → 따라서 이와 같이 **id를 의존성배열에 추가함으로써** 문제를 해결할 수 있었다. 
    
- 추천 제품 항목은 이제 반영이 잘 되는데, **스크롤의 위치가 초기화되지 않는 문제** 
    - 추천 제품을 클릭해서 새로운 제품의 상세정보 페이지로 이동했음에도 불구하고 이전페이지의 비슷한제품추천목록에서 스크롤한 위치가 그대로 유지되어있음! 
    - 원인 : **리액트 라우터**에서는 스크롤의 위치가 자동 초기화되지 않는다고 한다
    - 해결책 : `ScrollContainer` 컴포넌트 내에서 **useEffect**를 사용해서 **scrollTo 값**을 조절해보자
        - 서버통신 커스텀훅과는 달리 해당 컴포넌트는 id 값을 props로 받지 않아서 id 값에 따른 useEffect 실행이 불가능하다. 따라서 `useLocation`을 사용해서 `pathname`을 받아와 **경로가 변경될 때마다** (사실상 id값이 변경될 때마다) 실행해주도록 했다.
        - 현재 가로스크롤에 사용중인 `react-indiana-drag-scroll`의 공식문서를 통해 Properties를 알아보았고, 라이브러리가 제공하는 컨테이너에 **ref**를 지정해줄 수 있는 `innerRef` 속성을 발견했다.
        - ➡️**innerRef**를 통해 스크롤 컨테이너 컴포넌트에 접근해서,**pathname이 변할 때마다** `ref.current.scrollTo`로 스크롤 값을 초기화하여 해결 
        
        ```jsx
        // CustomScrollContainer.tsx
        
        const { pathname } = useLocation();
          const ref = useRef<HTMLElement>(null);
        
          useEffect(() => {
            if (!ref.current) return;
            ref.current.scrollTo(0, 0);
          }, [pathname]);
        ```

