### PR TITLE
[OrderPage] 2차 QA

### DIFF
--- a/src/components/Order/DeliveryInfo.tsx
+++ b/src/components/Order/DeliveryInfo.tsx
@@ -112,7 +112,8 @@ const St = {
   `,
   Info: styled.li`
     & > label {
-      margin: 2rem 0rem 1rem 0rem;
+      display: block;
+      margin-bottom: 1rem;
 
       ${({ theme }) => theme.fonts.body_medium_14};
       color: ${({ theme }) => theme.colors.gray3};
@@ -120,7 +121,6 @@ const St = {
     & input {
       width: 100%;
       padding: 1.2rem 2rem;
-      margin-top: 1rem;
       background-color: ${({ theme }) => theme.colors.bg};
       border-width: 0rem;
       border-radius: 0.5rem;
@@ -149,7 +149,6 @@ const St = {
   `,
   SearchBtn: styled.button`
     padding: 1.3rem 1.6rem;
-    margin-top: 1rem;
 
     background-color: ${({ theme }) => theme.colors.gray7};
     border-radius: 0.6rem;

--- a/src/components/Order/DeliveryInfo.tsx
+++ b/src/components/Order/DeliveryInfo.tsx
@@ -148,7 +148,9 @@ const St = {
     gap: 1.2rem;
   `,
   SearchBtn: styled.button`
-    padding: 1.3rem 1.6rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     background-color: ${({ theme }) => theme.colors.gray7};
     border-radius: 0.6rem;

--- a/src/components/Order/DeliveryInfo.tsx
+++ b/src/components/Order/DeliveryInfo.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import sliceMaxLength from '../../utils/sliceMaxLength';
 
 interface DeliveryInfoProps {
   handleModal: () => void;
@@ -23,14 +24,6 @@ const DeliveryInfo = ({
   detailAddress,
   setDetailAddress,
 }: DeliveryInfoProps) => {
-  // 자동 하이픈
-  const sliceMaxLength = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.target.value = e.target.value
-      .replace(/[^0-9]/g, '')
-      .replace(/^(\d{0,3})(\d{0,4})(\d{0,4})$/g, '$1-$2-$3')
-      .replace(/(-{1,2})$/g, '');
-  };
-
   return (
     <St.Wrapper>
       <St.Title>배송 정보</St.Title>
@@ -55,7 +48,7 @@ const DeliveryInfo = ({
             name='phone'
             maxLength={13}
             value={phone}
-            onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e)} // 자동 하이픈
+            onInput={(e: React.ChangeEvent<HTMLInputElement>) => sliceMaxLength(e, 13, 'phoneNum')}
             onChange={(e) => {
               setPhone(e.target.value);
             }}

--- a/src/components/Order/DeliveryInfo.tsx
+++ b/src/components/Order/DeliveryInfo.tsx
@@ -125,6 +125,7 @@ const St = {
       border-width: 0rem;
       border-radius: 0.5rem;
       ${({ theme }) => theme.fonts.body_medium_16};
+      color: ${({ theme }) => theme.colors.gray5};
 
       &::placeholder {
         color: ${({ theme }) => theme.colors.gray2};

--- a/src/components/Order/PaymentInfo.tsx
+++ b/src/components/Order/PaymentInfo.tsx
@@ -30,7 +30,7 @@ const PaymentInfo = ({
           </St.MainText>
         </St.PointText>
         <St.PointText>
-          <St.MainText>남는 포인트</St.MainText>
+          <St.MainText>결제 후 남는 포인트</St.MainText>
           <St.MainText>
             <span>{resultPoint && resultPoint.toLocaleString()}</span>
             <span>P</span>

--- a/src/components/Order/RefundInfo.tsx
+++ b/src/components/Order/RefundInfo.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { IcArrowRightDark } from '../../assets/icon';
+import { IcArrowRightGray4 } from '../../assets/icon';
 import ic_check from '../../assets/icon/ic_check.svg';
 import ic_check_selected from '../../assets/icon/ic_check_selected.svg';
 
@@ -14,7 +14,7 @@ const RefundInfo = ({ setSheetOpen, setAgree }: RefundInfoProps) => {
       <label htmlFor='agree'></label>
       <St.Button onClick={() => setSheetOpen(true)}>
         <St.Text>타투어 환불 정책에 동의합니다</St.Text>
-        <IcArrowRightDark />
+        <IcArrowRightGray4 />
       </St.Button>
     </St.Wrapper>
   );

--- a/src/libs/hooks/order/useGetOrdersheet.tsx
+++ b/src/libs/hooks/order/useGetOrdersheet.tsx
@@ -28,10 +28,17 @@ export interface getUserOrderPointResProps {
   lacked: boolean;
 }
 
+export interface getUserProfileInfoProps {
+  id: number;
+  name: string;
+  phoneNumber: string;
+}
+
 export interface OrderSheetProps {
   getOrderSheetStickerInfo: getOrderSheetStickerInfoProps;
   getOrderAmountRes: getOrderAmountResProps;
   getUserOrderPointRes: getUserOrderPointResProps;
+  userProfileInfo: getUserProfileInfoProps;
 }
 
 interface OrderSheetResponse {

--- a/src/page/Order/OrderPage.tsx
+++ b/src/page/Order/OrderPage.tsx
@@ -29,8 +29,8 @@ const OrderPage = () => {
   const [isSheetOpen, setSheetOpen] = useState(false);
 
   const [isComplete, setComplete] = useState(false);
-  const [input, setInput] = useState<string>('기본값');
-  const [phone, setPhone] = useState<string>('010-0000-0000');
+  const [input, setInput] = useState<string>('');
+  const [phone, setPhone] = useState<string>('');
   const [address, setAddress] = useState<string>(''); // 우편번호
   const [firstAddress, setFirstAddress] = useState<string>(''); // 첫주소
   const [detailAddress, setDetailAddress] = useState<string>(''); // 세부주소
@@ -47,6 +47,12 @@ const OrderPage = () => {
     baseAddress: firstAddress,
     detailAddress: detailAddress,
   };
+
+  useEffect(() => {
+    if (!response) return;
+    setInput(response.userProfileInfo.name);
+    setPhone(response.userProfileInfo.phoneNumber);
+  }, [response]);
 
   useEffect(() => {
     if (input === '' || phone === '' || address === '' || detailAddress === '' || agree === false) {

--- a/src/page/Order/OrderPage.tsx
+++ b/src/page/Order/OrderPage.tsx
@@ -51,7 +51,12 @@ const OrderPage = () => {
   useEffect(() => {
     if (!response) return;
     setInput(response.userProfileInfo.name);
-    setPhone(response.userProfileInfo.phoneNumber);
+    setPhone(
+      response.userProfileInfo.phoneNumber
+        .replace(/[^0-9]/g, '')
+        .replace(/^(\d{0,3})(\d{0,4})(\d{0,4})$/g, '$1-$2-$3')
+        .replace(/(-{1,2})$/g, ''),
+    );
   }, [response]);
 
   useEffect(() => {


### PR DESCRIPTION
## 🔥 Related Issues
resolved #493 

## 💜 작업 내용
![Slide 16_9 - 17](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/9075b8dc-30ab-405e-9592-9392b91ab8ed)
![Slide 16_9 - 18](https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/69822080-0783-48b9-9b14-4c43c7457a7a)


## ✅ PR Point
아래거 이슈 하나 외엔 다 단순 css 수정입니다! 

- **서버에서 불러온 유저정보로 input 기본값 세팅**
    - 처음엔 input과 phone의 state값의 기본값으로 바로 서버에서 받은 값들을 넣어줬는데, 최초에 response가 undefined로 불러와질때 때문에 기본값이 빈 텍스트로 채워져버리는 문제 봉착.
    - 따라서 response가 update될때 새로 state를 set하도록 아래와 같이 useEffect로 구현함.
        
        ```jsx
        useEffect(() => {
            setInput(response?.userProfileInfo.name);
            setPhone(response?.userProfileInfo.phoneNumber);
          }, [response]);
        ```
        
    - input에는 서버에서 받아온 유저 정보가 성공적으로 박혔지만, 갑자기 아래와 같은 Warning 발생
        <img width="491" alt="%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202023-08-19%20%EC%98%A4%ED%9B%84%2010 32 53" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/5c5ce410-67da-40c4-ba3a-348c26688aff">

        
        → 찾아보니 input의 value에 undefined type이 가능한 경우가 오면 안된다고 !
        
         → 구체적인 코드에서는 **setter 내부의 옵셔널체이닝** 때문에 발생한 Warning이었다. 
        
    
    ➡️ 따라서 옵셔널 체이닝을 없애되, response가 undefined일 경우에 발생하는 에러를 막기 위해 useEffect 최상단에 빠른 return문을 추가해 주어 해결하였다. 
    
    ```jsx
    useEffect(() => {
        if (!response) return;  // 여기!
        setInput(response.userProfileInfo.name);
        setPhone(response.userProfileInfo.phoneNumber);
      }, [response]);
    ```
    
    - 추후 해당 코드에 **phoneNumber에 자동 하이픈을 입력**하기 위해 **점화식과 replace 코드**도 추가해주었다.
