### PR TITLE
[Custom: noDesign] price + receipt 페이지들까지 noDesign 통합 페이지에 우선 통합

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -21,8 +21,8 @@ import OnBoardingPage from './page/Custom/Common/OnBoardingPage';
 // import CustomThemeLayout from './components/Custom/HaveDesign/CustomTheme/CustomThemeLayout';
 // import SelectKeywordLayout from './components/Custom/HaveDesign/SelectKeyword/SelectKeywordLayout';
 // import StylingColorLayout from './components/Custom/HaveDesign/SelectColor/StylingColorLayout';
-import PricePage from './components/Custom/Common/PriceLayout';
-import ReceiptLayout from './components/Custom/Common/Receipt/ReceiptLayout';
+// import PricePage from './components/Custom/Common/PriceLayout';
+// import ReceiptLayout from './components/Custom/Common/Receipt/ReceiptLayout';
 
 import SearchPage from './page/Search/SearchPage';
 import SearchResultPage from './page/Search/SearchResultPage';

--- a/src/components/Custom/Common/PriceLayout.tsx
+++ b/src/components/Custom/Common/PriceLayout.tsx
@@ -13,10 +13,26 @@ import Header from '../../Header';
 import PageLayout from '../../PageLayout';
 
 interface PriceLayoutProps {
+  step: number;
   setStep: React.Dispatch<React.SetStateAction<number>>;
+  customId: number;
+  size: string;
+  name: string;
+  demand: string;
+  customImages: FileList | undefined;
+  handDrawingImage?: string;
 }
 
-const PriceLayout = ({ setStep }: PriceLayoutProps) => {
+const PriceLayout = ({
+  step,
+  setStep,
+  customId,
+  size,
+  name,
+  demand,
+  customImages,
+  handDrawingImage,
+}: PriceLayoutProps) => {
   const [modalOn, setModalOn] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
   const [count, setCount] = useState(1);
@@ -26,32 +42,44 @@ const PriceLayout = ({ setStep }: PriceLayoutProps) => {
     setIsCompletedState(true);
   };
 
-  const navigate = useNavigate();
-  const location = useLocation();
+  // const navigate = useNavigate();
+  // const location = useLocation();
 
-  const haveDesign = location.state ? location.state.haveDesign : null;
-  const prevCustomInfo = location.state ? location.state.customInfo : null;
-  const handDrawingImage = location.state ? location.state.handDrawingImage : null;
-  const customImages = location.state ? location.state.customImages : null;
-  const size = location.state ? location.state.customInfo.size : null;
-  const price = location.state ? location.state.customInfo.price : null;
-  const isCompleted = location.state ? location.state.customInfo.isCompleted : null;
+  // const haveDesign = location.state ? location.state.haveDesign : null;
+  // const prevCustomInfo = location.state ? location.state.customInfo : null;
+  // const handDrawingImage = location.state ? location.state.handDrawingImage : null;
+  // const customImages = location.state ? location.state.customImages : null;
+  // const size = location.state ? location.state.customInfo.size : null;
+  // const price = location.state ? location.state.customInfo.price : null;
+  // const isCompleted = location.state ? location.state.customInfo.isCompleted : null;
 
-  const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
+  // const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
 
   // useEffect(() => {
   //   if (!location.state) navigate('/onboarding');
   // }, [location.state, navigate]);
 
+  // const customInfo = {
+  //   ...prevCustomInfo,
+  //   haveDesign: haveDesign,
+  //   viewCount: CUSTOM_VIEW_COUNT,
+  //   handDrawingImage: handDrawingImage,
+  //   customImages: customImages,
+  //   count: count,
+  //   price: price,
+  //   isCompleted: isCompleted,
+  // };
+
   const customInfo = {
-    ...prevCustomInfo,
-    haveDesign: haveDesign,
-    viewCount: CUSTOM_VIEW_COUNT,
-    handDrawingImage: handDrawingImage,
-    customImages: customImages,
+    customId: customId,
+    size: size,
+    name: name,
+    demand: demand,
     count: count,
-    price: price,
-    isCompleted: isCompleted,
+    isPublic: isPublic,
+    isCompleted: isCompletedState,
+    price: 0,
+    viewCount: step,
   };
 
   const renderPriceLayoutHeader = () => {
@@ -67,7 +95,7 @@ const PriceLayout = ({ setStep }: PriceLayoutProps) => {
           />
         }
         transparent={true}
-        progressBar={<ProgressBar curStep={CUSTOM_VIEW_COUNT} maxStep={CUSTOM_VIEW_COUNT} />}
+        progressBar={<ProgressBar curStep={step} maxStep={step} />}
       />
     );
   };
@@ -77,13 +105,12 @@ const PriceLayout = ({ setStep }: PriceLayoutProps) => {
       renderHeader={renderPriceLayoutHeader}
       footer={
         <PriceFooter
-          haveDesign={haveDesign}
           customInfo={customInfo}
-          handDrawingImage={handDrawingImage}
+          handDrawingImage={handDrawingImage ? handDrawingImage : ''}
           customImages={customImages}
-          isCompleted={isCompleted}
           handleCompletedState={handleCompletedState}
           isCompletedState={isCompletedState}
+          setStep={setStep}
         />
       }
     >

--- a/src/components/Custom/Common/PriceLayout.tsx
+++ b/src/components/Custom/Common/PriceLayout.tsx
@@ -34,9 +34,10 @@ const PriceLayout = ({
   const [modalOn, setModalOn] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
   const [count, setCount] = useState(1);
-  const [isCompletedState, setIsCompletedState] = useState(true);
+  const [isCompletedState, setIsCompletedState] = useState(true); //이거 왜 꼭 state로 쓰는지 궁금합니다! 꼭 필요한 부분인가요?
 
   const handleCompletedState = () => {
+    //이 코드의 역할이 궁금합니다! 꼭 필요한 함수인가요?
     setIsCompletedState(true);
   };
 

--- a/src/components/Custom/Common/PriceLayout.tsx
+++ b/src/components/Custom/Common/PriceLayout.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { IcBackDark } from '../../../assets/icon';
 import CancelBtn from '../../../common/Header/CancelBtn';
@@ -41,40 +40,12 @@ const PriceLayout = ({
     setIsCompletedState(true);
   };
 
-  // const navigate = useNavigate();
-  // const location = useLocation();
-
-  // const haveDesign = location.state ? location.state.haveDesign : null;
-  // const prevCustomInfo = location.state ? location.state.customInfo : null;
-  // const handDrawingImage = location.state ? location.state.handDrawingImage : null;
-  // const customImages = location.state ? location.state.customImages : null;
-  // const size = location.state ? location.state.customInfo.size : null;
-  // const price = location.state ? location.state.customInfo.price : null;
-  // const isCompleted = location.state ? location.state.customInfo.isCompleted : null;
-
-  // const CUSTOM_VIEW_COUNT = haveDesign ? 7 : 4;
-
-  // useEffect(() => {
-  //   if (!location.state) navigate('/onboarding');
-  // }, [location.state, navigate]);
-
-  // const customInfo = {
-  //   ...prevCustomInfo,
-  //   haveDesign: haveDesign,
-  //   viewCount: CUSTOM_VIEW_COUNT,
-  //   handDrawingImage: handDrawingImage,
-  //   customImages: customImages,
-  //   count: count,
-  //   price: price,
-  //   isCompleted: isCompleted,
-  // };
-
   const updatedCustomInfo = {
     ...customInfo,
     count: count,
     isPublic: isPublic,
     isCompleted: true,
-    price: 0,
+    price: 0, //price 최상단(여기 layout 컴포넌트)에서 관리할 수 있게 + 할인 로직까지 포함해서 수정 부탁해용 !!
     viewCount: step,
   };
 

--- a/src/components/Custom/Common/PriceLayout.tsx
+++ b/src/components/Custom/Common/PriceLayout.tsx
@@ -11,7 +11,7 @@ import PriceFooter from '../PriceFooter';
 import PriceHeading from '../PriceHeading';
 import Header from '../../Header';
 import PageLayout from '../../PageLayout';
-import { customInfoType } from '../../../types/customInfoType';
+import { customInfoType, resCustomInfoType } from '../../../types/customInfoType';
 
 interface PriceLayoutProps {
   step: number;
@@ -21,7 +21,7 @@ interface PriceLayoutProps {
   customImages: FileList | undefined;
   handDrawingImage?: string;
 
-  setReceiptData: React.Dispatch<React.SetStateAction<object | undefined>>;
+  setReceiptData: React.Dispatch<React.SetStateAction<resCustomInfoType | undefined>>;
 }
 
 const PriceLayout = ({

--- a/src/components/Custom/Common/PriceLayout.tsx
+++ b/src/components/Custom/Common/PriceLayout.tsx
@@ -11,32 +11,31 @@ import PriceFooter from '../PriceFooter';
 import PriceHeading from '../PriceHeading';
 import Header from '../../Header';
 import PageLayout from '../../PageLayout';
+import { customInfoType } from '../../../types/customInfoType';
 
 interface PriceLayoutProps {
   step: number;
   setStep: React.Dispatch<React.SetStateAction<number>>;
-  customId: number;
-  size: string;
-  name: string;
-  demand: string;
+
+  customInfo: customInfoType;
   customImages: FileList | undefined;
   handDrawingImage?: string;
+
+  setReceiptData: React.Dispatch<React.SetStateAction<object | undefined>>;
 }
 
 const PriceLayout = ({
   step,
   setStep,
-  customId,
-  size,
-  name,
-  demand,
+  customInfo,
   customImages,
   handDrawingImage,
+  setReceiptData,
 }: PriceLayoutProps) => {
   const [modalOn, setModalOn] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
   const [count, setCount] = useState(1);
-  const [isCompletedState, setIsCompletedState] = useState(false);
+  const [isCompletedState, setIsCompletedState] = useState(true);
 
   const handleCompletedState = () => {
     setIsCompletedState(true);
@@ -70,14 +69,11 @@ const PriceLayout = ({
   //   isCompleted: isCompleted,
   // };
 
-  const customInfo = {
-    customId: customId,
-    size: size,
-    name: name,
-    demand: demand,
+  const updatedCustomInfo = {
+    ...customInfo,
     count: count,
     isPublic: isPublic,
-    isCompleted: isCompletedState,
+    isCompleted: true,
     price: 0,
     viewCount: step,
   };
@@ -105,18 +101,19 @@ const PriceLayout = ({
       renderHeader={renderPriceLayoutHeader}
       footer={
         <PriceFooter
-          customInfo={customInfo}
+          customInfo={updatedCustomInfo}
           handDrawingImage={handDrawingImage ? handDrawingImage : ''}
           customImages={customImages}
           handleCompletedState={handleCompletedState}
           isCompletedState={isCompletedState}
           setStep={setStep}
+          setReceiptData={setReceiptData}
         />
       }
     >
       <St.TopWrapper>
         <PriceHeading />
-        <CountPrice isPublic={isPublic} setCount={setCount} size={size} />
+        <CountPrice isPublic={isPublic} setCount={setCount} size={customInfo.size} />
       </St.TopWrapper>
       <MakePublic isPublic={isPublic} setIsPublic={setIsPublic} />
     </PageLayout>

--- a/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
@@ -1,4 +1,3 @@
-// import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { resCustomInfoType } from '../../../../types/customInfoType';
 

--- a/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
@@ -1,8 +1,9 @@
-import { useLocation } from 'react-router-dom';
+// import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
+import { resCustomInfoType } from '../../../../types/customInfoType';
 
 interface ReceiptDetailProps {
-  receiptData: object | undefined;
+  receiptData: resCustomInfoType | undefined;
 }
 
 const ReceiptDetail = ({ receiptData }: ReceiptDetailProps) => {

--- a/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
@@ -6,18 +6,19 @@ interface ReceiptDetailProps {
 }
 
 const ReceiptDetail = ({ receiptData }: ReceiptDetailProps) => {
-  // const location = useLocation();
+  //typeError 방지용 early return
+  // if (receiptData === undefined) return;
 
-  const size = receiptData ? receiptData?.size : '';
-  const count = receiptData ? receiptData?.count : 1;
-  const isColored = receiptData ? receiptData?.isColored : false;
-  const name = receiptData ? receiptData?.name : '';
-  const description = receiptData ? receiptData?.description : '';
-  const themes = receiptData ? receiptData?.themes : [];
-  const styles = receiptData ? receiptData?.styles : [];
-  const mainImageUrl = receiptData ? receiptData?.mainImageUrl : '';
-  const handDrawingImageUrl = receiptData ? receiptData?.handDrawingImageUrl : '';
-  const images = receiptData ? receiptData?.images : [];
+  const size = receiptData ? receiptData.size : '';
+  const count = receiptData ? receiptData.count : 1;
+  const isColored = receiptData ? receiptData.isColored : false;
+  const name = receiptData ? receiptData.name : '';
+  const description = receiptData ? receiptData.description : '';
+  const themes = receiptData ? receiptData.themes : [];
+  const styles = receiptData ? receiptData.styles : [];
+  const mainImageUrl = receiptData ? receiptData.mainImageUrl : '';
+  const handDrawingImageUrl = receiptData ? receiptData.handDrawingImageUrl : '';
+  const images = receiptData ? receiptData.images : [];
   const previewURL = [...themes, ...styles];
   const imagesArray = handDrawingImageUrl
     ? [mainImageUrl, ...images, handDrawingImageUrl]

--- a/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
@@ -15,6 +15,7 @@ const ReceiptDetail = ({ receiptData }: ReceiptDetailProps) => {
   const isColored = receiptData ? receiptData.isColored : false;
   const name = receiptData ? receiptData.name : '';
   const description = receiptData ? receiptData.description : '';
+  const demand = receiptData ? receiptData.demand : '';
   const themes = receiptData ? receiptData.themes : [];
   const styles = receiptData ? receiptData.styles : [];
   const mainImageUrl = receiptData ? receiptData.mainImageUrl : '';
@@ -60,11 +61,11 @@ const ReceiptDetail = ({ receiptData }: ReceiptDetailProps) => {
       </St.DetailWrapper>
       <St.DetailWrapper>
         <St.DetailSubject>주제</St.DetailSubject>
-        <St.DetailContent>{name}</St.DetailContent>
+        <St.DetailContent>{description}</St.DetailContent>
       </St.DetailWrapper>
       <St.DetailWrapper className='request'>
         <St.DetailSubject>요청사항</St.DetailSubject>
-        <St.DetailContent>{description}</St.DetailContent>
+        <St.DetailContent>{demand}</St.DetailContent>
       </St.DetailWrapper>
     </St.ReceiptDetailWrapper>
   );

--- a/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
@@ -8,19 +8,22 @@ interface ReceiptDetailProps {
 
 const ReceiptDetail = ({ receiptData }: ReceiptDetailProps) => {
   //typeError 방지용 early return
-  // if (receiptData === undefined) return;
+  if (receiptData === undefined) return;
 
-  const size = receiptData ? receiptData.size : '';
-  const count = receiptData ? receiptData.count : 1;
-  const isColored = receiptData ? receiptData.isColored : false;
-  const name = receiptData ? receiptData.name : '';
-  const description = receiptData ? receiptData.description : '';
-  const demand = receiptData ? receiptData.demand : '';
-  const themes = receiptData ? receiptData.themes : [];
-  const styles = receiptData ? receiptData.styles : [];
-  const mainImageUrl = receiptData ? receiptData.mainImageUrl : '';
-  const handDrawingImageUrl = receiptData ? receiptData.handDrawingImageUrl : '';
-  const images = receiptData ? receiptData.images : [];
+  const {
+    size,
+    count,
+    isColored,
+    name,
+    description,
+    demand,
+    themes,
+    styles,
+    mainImageUrl,
+    handDrawingImageUrl,
+    images,
+  } = receiptData;
+
   const previewURL = [...themes, ...styles];
   const imagesArray = handDrawingImageUrl
     ? [mainImageUrl, ...images, handDrawingImageUrl]

--- a/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptDetail.tsx
@@ -1,19 +1,23 @@
 import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-const ReceiptDetail = () => {
-  const location = useLocation();
+interface ReceiptDetailProps {
+  receiptData: object | undefined;
+}
 
-  const size = location.state ? location.state.data.size : '';
-  const count = location.state ? location.state.data.count : 1;
-  const isColored = location.state ? location.state.data.isColored : false;
-  const name = location.state ? location.state.data.name : '';
-  const description = location.state ? location.state.data.description : '';
-  const themes = location.state ? location.state.data.themes : [];
-  const styles = location.state ? location.state.data.styles : [];
-  const mainImageUrl = location.state ? location.state.data.mainImageUrl : '';
-  const handDrawingImageUrl = location.state ? location.state.data.handDrawingImageUrl : '';
-  const images = location.state ? location.state.data.images : [];
+const ReceiptDetail = ({ receiptData }: ReceiptDetailProps) => {
+  // const location = useLocation();
+
+  const size = receiptData ? receiptData?.size : '';
+  const count = receiptData ? receiptData?.count : 1;
+  const isColored = receiptData ? receiptData?.isColored : false;
+  const name = receiptData ? receiptData?.name : '';
+  const description = receiptData ? receiptData?.description : '';
+  const themes = receiptData ? receiptData?.themes : [];
+  const styles = receiptData ? receiptData?.styles : [];
+  const mainImageUrl = receiptData ? receiptData?.mainImageUrl : '';
+  const handDrawingImageUrl = receiptData ? receiptData?.handDrawingImageUrl : '';
+  const images = receiptData ? receiptData?.images : [];
   const previewURL = [...themes, ...styles];
   const imagesArray = handDrawingImageUrl
     ? [mainImageUrl, ...images, handDrawingImageUrl]

--- a/src/components/Custom/Common/Receipt/ReceiptLayout.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptLayout.tsx
@@ -7,9 +7,10 @@ import PageLayout from '../../../PageLayout';
 import ReceiptDetail from './ReceiptDetail';
 import ReceiptFooter from './ReceiptFooter';
 import Submitted from './Submitted';
+import { resCustomInfoType } from '../../../../types/customInfoType';
 
 interface ReceiptLayoutProps {
-  receiptData: object | undefined;
+  receiptData: resCustomInfoType | undefined;
 }
 
 const ReceiptLayout = ({ receiptData }: ReceiptLayoutProps) => {

--- a/src/components/Custom/Common/Receipt/ReceiptLayout.tsx
+++ b/src/components/Custom/Common/Receipt/ReceiptLayout.tsx
@@ -8,7 +8,11 @@ import ReceiptDetail from './ReceiptDetail';
 import ReceiptFooter from './ReceiptFooter';
 import Submitted from './Submitted';
 
-const ReceiptLayout = () => {
+interface ReceiptLayoutProps {
+  receiptData: object | undefined;
+}
+
+const ReceiptLayout = ({ receiptData }: ReceiptLayoutProps) => {
   const [modalOn, setModalOn] = useState(false);
 
   const renderReceiptLayoutHeader = () => {
@@ -31,7 +35,7 @@ const ReceiptLayout = () => {
   return (
     <PageLayout renderHeader={renderReceiptLayoutHeader} footer={<ReceiptFooter />}>
       <Submitted />
-      <ReceiptDetail />
+      <ReceiptDetail receiptData={receiptData} />
     </PageLayout>
   );
 };

--- a/src/components/Custom/Common/Size/CustomSizeLayout.tsx
+++ b/src/components/Custom/Common/Size/CustomSizeLayout.tsx
@@ -13,9 +13,16 @@ interface CustomSizeLayoutProps {
   size: string;
   setSize: React.Dispatch<React.SetStateAction<string>>;
   haveDesign: boolean;
+  customId: number | undefined;
 }
 
-const CustomSizeLayout = ({ setStep, size, setSize, haveDesign }: CustomSizeLayoutProps) => {
+const CustomSizeLayout = ({
+  setStep,
+  size,
+  setSize,
+  haveDesign,
+  customId,
+}: CustomSizeLayoutProps) => {
   const [modalOn, setModalOn] = useState(false);
   const [isActiveNext, setIsActiveNext] = useState(false);
 
@@ -41,7 +48,13 @@ const CustomSizeLayout = ({ setStep, size, setSize, haveDesign }: CustomSizeLayo
     <PageLayout
       renderHeader={renderCustomSizePageHeader}
       footer={
-        <NoDesignFooter isActiveNext={isActiveNext} setStep={setStep} navigateURL={navigateURL} />
+        <NoDesignFooter
+          isActiveNext={isActiveNext}
+          setStep={setStep}
+          navigateURL={navigateURL}
+          size={size}
+          customId={customId}
+        />
       }
     >
       <CustomSelectSize setIsActiveNext={setIsActiveNext} setSize={setSize} size={size} />

--- a/src/components/Custom/CountPrice.tsx
+++ b/src/components/Custom/CountPrice.tsx
@@ -10,7 +10,7 @@ import { PRICE } from '../../assets/data/PRICE';
 interface CountPriceProps {
   isPublic: boolean;
   setCount: React.Dispatch<React.SetStateAction<number>>;
-  size: string;
+  size: string | undefined;
 }
 
 const CountPrice = ({ isPublic, setCount, size }: CountPriceProps) => {

--- a/src/components/Custom/NoDesign/NoDesignFooter.tsx
+++ b/src/components/Custom/NoDesign/NoDesignFooter.tsx
@@ -5,13 +5,27 @@ interface NoDesignFooterProps {
   isActiveNext?: boolean;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   navigateURL?: string;
+  size: string;
+  customId?: number;
 }
 
-const NoDesignFooter = ({ isActiveNext = true, setStep, navigateURL }: NoDesignFooterProps) => {
+const NoDesignFooter = ({
+  isActiveNext = true,
+  setStep,
+  navigateURL,
+  size,
+  customId,
+}: NoDesignFooterProps) => {
   const navigate = useNavigate();
   const handleClickFooter = () => {
     {
-      navigateURL && navigate(navigateURL);
+      navigateURL &&
+        navigate(navigateURL, {
+          state: {
+            size: size,
+            customId: customId,
+          },
+        });
       isActiveNext && setStep((prev) => prev + 1);
     }
   };

--- a/src/components/Custom/NoDesign/NoDesignFooter.tsx
+++ b/src/components/Custom/NoDesign/NoDesignFooter.tsx
@@ -5,7 +5,8 @@ interface NoDesignFooterProps {
   isActiveNext?: boolean;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   navigateURL?: string;
-  size: string;
+  //지금은 해당 값들을 navigate으로 넘겨줘야 하기 때문에 필요한 props들 추후 통합 시 삭제 할 예정
+  size?: string;
   customId?: number;
 }
 

--- a/src/components/Custom/PriceFooter.tsx
+++ b/src/components/Custom/PriceFooter.tsx
@@ -12,11 +12,17 @@ interface PriceFooterProps {
   isCompleted?: boolean;
   handleCompletedState?: () => void;
   isCompletedState?: boolean;
-
   setStep: React.Dispatch<React.SetStateAction<number>>;
+  setReceiptData: React.Dispatch<React.SetStateAction<object | undefined>>;
 }
 
-const PriceFooter = ({ customInfo, handDrawingImage, customImages, setStep }: PriceFooterProps) => {
+const PriceFooter = ({
+  customInfo,
+  handDrawingImage,
+  customImages,
+  setStep,
+  setReceiptData,
+}: PriceFooterProps) => {
   // const navigate = useNavigate();
 
   const handleClickFooterBtn = async () => {
@@ -45,6 +51,8 @@ const PriceFooter = ({ customInfo, handDrawingImage, customImages, setStep }: Pr
         },
       });
       console.log('data', data.data, '!!!!!');
+      setReceiptData(data.data);
+
       // navigate('/receipt', {
       //   state: {
       //     data: data.data,

--- a/src/components/Custom/PriceFooter.tsx
+++ b/src/components/Custom/PriceFooter.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { customInfoType, resCustomInfoType } from '../../types/customInfoType';
 import api from '../../libs/api';
@@ -7,7 +6,7 @@ import React from 'react';
 interface PriceFooterProps {
   haveDesign?: boolean;
   customInfo: customInfoType;
-  handDrawingImage: string;
+  handDrawingImage: string; //handDrawingImage string으로 넘기면 되는지 확인 부탁!(swagger에는 string으로 명시 됨)
   customImages: FileList | undefined;
   isCompleted?: boolean;
   handleCompletedState?: () => void;
@@ -28,36 +27,28 @@ const PriceFooter = ({
   const handleClickFooterBtn = async () => {
     const formData = new FormData();
     try {
-      // handleCompletedState(); 이렇게 하면 안되는 듯,,
+      // 1. handDrawingImage(손 그림) append
       formData.append('handDrawingImage', handDrawingImage);
-      // const newCustomInfo = {
-      //   ...customInfo,
-      //   isCompleted: true,
-      // };
-      const newCustomInfo = customInfo;
-      const json = JSON.stringify(newCustomInfo);
-      const blob = new Blob([json], { type: 'application/json' });
 
+      // 2. customInfo(커스텀 정보들) append
+      const json = JSON.stringify(customInfo);
+      const blob = new Blob([json], { type: 'application/json' });
       formData.append('customInfo', blob);
 
+      // 3. customImage(도안 이미지) append
       if (customImages) {
         for (let i = 0; i < customImages.length; i++) {
           formData.append('customImages', customImages.item(i) as File);
         }
       }
+
       const { data } = await api.patch('/custom/update', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },
       });
-      console.log('data', data.data, '!!!!!');
+      // console.log('data', data.data, '!!!!!');
       setReceiptData(data.data);
-
-      // navigate('/receipt', {
-      //   state: {
-      //     data: data.data,
-      //   },
-      // });
       setStep((prev) => prev + 1);
     } catch (err) {
       console.log('Error', err);

--- a/src/components/Custom/PriceFooter.tsx
+++ b/src/components/Custom/PriceFooter.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
-import { customInfoType } from '../../types/customInfoType';
+import { customInfoType, resCustomInfoType } from '../../types/customInfoType';
 import api from '../../libs/api';
 import React from 'react';
 
@@ -13,7 +13,7 @@ interface PriceFooterProps {
   handleCompletedState?: () => void;
   isCompletedState?: boolean;
   setStep: React.Dispatch<React.SetStateAction<number>>;
-  setReceiptData: React.Dispatch<React.SetStateAction<object | undefined>>;
+  setReceiptData: React.Dispatch<React.SetStateAction<resCustomInfoType | undefined>>;
 }
 
 const PriceFooter = ({

--- a/src/components/Custom/PriceFooter.tsx
+++ b/src/components/Custom/PriceFooter.tsx
@@ -2,29 +2,33 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { customInfoType } from '../../types/customInfoType';
 import api from '../../libs/api';
+import React from 'react';
 
 interface PriceFooterProps {
   haveDesign?: boolean;
-  customInfo?: customInfoType;
-  handDrawingImage: File;
-  customImages?: FileList | null;
-  isCompleted: boolean;
-  handleCompletedState: () => void;
-  isCompletedState: boolean;
+  customInfo: customInfoType;
+  handDrawingImage: string;
+  customImages: FileList | undefined;
+  isCompleted?: boolean;
+  handleCompletedState?: () => void;
+  isCompletedState?: boolean;
+
+  setStep: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const PriceFooter = ({ customInfo, handDrawingImage, customImages }: PriceFooterProps) => {
-  const navigate = useNavigate();
+const PriceFooter = ({ customInfo, handDrawingImage, customImages, setStep }: PriceFooterProps) => {
+  // const navigate = useNavigate();
 
   const handleClickFooterBtn = async () => {
     const formData = new FormData();
     try {
       // handleCompletedState(); 이렇게 하면 안되는 듯,,
       formData.append('handDrawingImage', handDrawingImage);
-      const newCustomInfo = {
-        ...customInfo,
-        isCompleted: true,
-      };
+      // const newCustomInfo = {
+      //   ...customInfo,
+      //   isCompleted: true,
+      // };
+      const newCustomInfo = customInfo;
       const json = JSON.stringify(newCustomInfo);
       const blob = new Blob([json], { type: 'application/json' });
 
@@ -41,11 +45,12 @@ const PriceFooter = ({ customInfo, handDrawingImage, customImages }: PriceFooter
         },
       });
       console.log('data', data.data, '!!!!!');
-      navigate('/receipt', {
-        state: {
-          data: data.data,
-        },
-      });
+      // navigate('/receipt', {
+      //   state: {
+      //     data: data.data,
+      //   },
+      // });
+      setStep((prev) => prev + 1);
     } catch (err) {
       console.log('Error', err);
     }

--- a/src/page/Custom/Common/CommonCustomPage.tsx
+++ b/src/page/Custom/Common/CommonCustomPage.tsx
@@ -24,7 +24,13 @@ const CommonCustomPage = () => {
       );
     case 1:
       return (
-        <CustomSizeLayout setStep={setStep} size={size} setSize={setSize} haveDesign={haveDesign} />
+        <CustomSizeLayout
+          setStep={setStep}
+          size={size}
+          setSize={setSize}
+          haveDesign={haveDesign}
+          customId={customId}
+        />
       );
   }
 };

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 // import CustomSizePage from '../Common/CustomSizePage';
-import PricePage from '../../../components/Custom/Common/PriceLayout';
 import CustomImgLayout from '../../../components/Custom/NoDesign/Img/CustomImgLayout';
 import CustomRequestLayout from '../../../components/Custom/NoDesign/Request/CustomRequestLayout';
+import PriceLayout from '../../../components/Custom/Common/PriceLayout';
+import { useLocation } from 'react-router-dom';
+import ReceiptLayout from '../../../components/Custom/Common/Receipt/ReceiptLayout';
 
 const NoDesignCustomPage = () => {
   //커스텀 신청서 플로우에 따른 각 단계별 컴포넌트 렌더링 플래그
@@ -16,6 +18,11 @@ const NoDesignCustomPage = () => {
   const [name, setName] = useState('');
   //요청사항 state
   const [demand, setDemand] = useState('');
+
+  const location = useLocation();
+
+  const size = location.state ? location.state.size : null;
+  const customId = location.state ? location.state.customId : null;
 
   //customSizePage가 공통으로 쓰여 아직 처리를 못해줘, step이 1부터 시작하도록 useEffect로 테스트 코드 추가. 추후 삭제 예정
   useEffect(() => {
@@ -45,7 +52,20 @@ const NoDesignCustomPage = () => {
       );
 
     case 3:
-      return <PricePage setStep={setStep} />;
+      return (
+        <PriceLayout
+          step={step}
+          setStep={setStep}
+          customId={customId}
+          size={size}
+          name={name}
+          demand={demand}
+          customImages={customImages}
+        />
+      );
+
+    case 4:
+      return <ReceiptLayout />;
   }
 };
 

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -22,9 +22,11 @@ const NoDesignCustomPage = () => {
 
   const location = useLocation();
 
+  // 앞에 size + customId 통합해놓은거에서 navigate로 내홨기 때문에 우선 navigate state로 관련 정보 불러옴
   const size = location.state ? location.state.size : null;
   const customId = location.state ? location.state.customId : null;
 
+  //patch에 보낼 정보들 객체로 모으기
   const customInfo = {
     customId: customId,
     size: size,
@@ -33,8 +35,8 @@ const NoDesignCustomPage = () => {
     viewCount: step,
   };
 
+  // patch 통신 response = receipt 뷰에 넘겨줘야 하는 정보들
   const [receiptData, setReceiptData] = useState<resCustomInfoType>();
-  console.log(receiptData);
 
   //customSizePage가 공통으로 쓰여 아직 처리를 못해줘, step이 1부터 시작하도록 useEffect로 테스트 코드 추가. 추후 삭제 예정
   useEffect(() => {

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -22,7 +22,7 @@ const NoDesignCustomPage = () => {
 
   const location = useLocation();
 
-  // 앞에 size + customId 통합해놓은거에서 navigate로 내홨기 때문에 우선 navigate state로 관련 정보 불러옴
+  // 앞에 size + customId 통합 해놓은거에서 우선 navigate state로 관련 정보 불러옴 추후 통합시 제거 예정
   const size = location.state ? location.state.size : null;
   const customId = location.state ? location.state.customId : null;
 

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -5,6 +5,7 @@ import CustomRequestLayout from '../../../components/Custom/NoDesign/Request/Cus
 import PriceLayout from '../../../components/Custom/Common/PriceLayout';
 import { useLocation } from 'react-router-dom';
 import ReceiptLayout from '../../../components/Custom/Common/Receipt/ReceiptLayout';
+import { resCustomInfoType } from '../../../types/customInfoType';
 
 const NoDesignCustomPage = () => {
   //커스텀 신청서 플로우에 따른 각 단계별 컴포넌트 렌더링 플래그
@@ -32,7 +33,7 @@ const NoDesignCustomPage = () => {
     viewCount: step,
   };
 
-  const [receiptData, setReceiptData] = useState<object>();
+  const [receiptData, setReceiptData] = useState<resCustomInfoType>();
   console.log(receiptData);
 
   //customSizePage가 공통으로 쓰여 아직 처리를 못해줘, step이 1부터 시작하도록 useEffect로 테스트 코드 추가. 추후 삭제 예정

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -74,7 +74,7 @@ const NoDesignCustomPage = () => {
       );
 
     case 4:
-      return <ReceiptLayout />;
+      return <ReceiptLayout receiptData={receiptData} />;
   }
 };
 

--- a/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
+++ b/src/page/Custom/NoDesign/NoDesignCustomPage.tsx
@@ -24,6 +24,17 @@ const NoDesignCustomPage = () => {
   const size = location.state ? location.state.size : null;
   const customId = location.state ? location.state.customId : null;
 
+  const customInfo = {
+    customId: customId,
+    size: size,
+    name: name,
+    demand: demand,
+    viewCount: step,
+  };
+
+  const [receiptData, setReceiptData] = useState<object>();
+  console.log(receiptData);
+
   //customSizePage가 공통으로 쓰여 아직 처리를 못해줘, step이 1부터 시작하도록 useEffect로 테스트 코드 추가. 추후 삭제 예정
   useEffect(() => {
     setStep(1);
@@ -56,11 +67,9 @@ const NoDesignCustomPage = () => {
         <PriceLayout
           step={step}
           setStep={setStep}
-          customId={customId}
-          size={size}
-          name={name}
-          demand={demand}
+          customInfo={customInfo}
           customImages={customImages}
+          setReceiptData={setReceiptData}
         />
       );
 

--- a/src/types/customInfoType.ts
+++ b/src/types/customInfoType.ts
@@ -13,3 +13,25 @@ export interface customInfoType {
   price?: number;
   viewCount?: number;
 }
+
+export interface resCustomInfoType {
+  id: number;
+  userId: number;
+  stickerId: number;
+  themes: Array<string>;
+  styles: Array<string>;
+  mainImageUrl: string;
+  handDrawingImageUrl: string;
+  images: Array<string>;
+  haveDesign: boolean;
+  size: string;
+  name: string;
+  description: string;
+  demand: string;
+  count: number;
+  isColored: boolean;
+  isPublic: boolean;
+  isCompleted: boolean;
+  process: string;
+  viewCount: number;
+}


### PR DESCRIPTION
## 🔥 Related Issues
resolved #497 

## 💜 작업 내용
- [x] `/custom`(select+size 통합 페이지)에서 size, customId 받아오기
- [x] pricePage를 noDesign 통합 페이지에 우선 통합
- [x] receiptPageg를 noDesign 통합 페이지에 우선 통합

## ✅ PR Point
### 1️⃣  `/custom`(select+size 통합 페이지)에서 size, customId 받아오기
* 아직 통합 안된 앞 플로우라서 /custom -> /haveDesign or /noDesign으로 navigate 됨. 그러나 size, customId 정보들은 /custom에서 받아와야 하므로 여기서는 navigate 시 state 전달 해주는걸 사용했습니다
* 이 과정에서 앞 pr에서 수정한 '/custom'관련 컴포넌트들에도 props, navigate 수정이 있었습니다
```ts
//noDesignFooter.tsx

const handleClickFooter = () => {
    {
      navigateURL &&
        navigate(navigateURL, {
          state: {
//여기서 navigate 시 필요한 값들 state로 넘겨주고
            size: size,
            customId: customId,
          },
        });
      isActiveNext && setStep((prev) => prev + 1);
    }
```
```ts
//NoDesignCustomPage.tsx

  const location = useLocation();

  // 앞에 size + customId 통합해놓은거에서 navigate로 내기 때문에 우선 navigate state로 관련 정보 불러옴
  const size = location.state ? location.state.size : null;
  const customId = location.state ? location.state.customId : null;
```
<hr/>
<br/>

### 2️⃣ pricePage를 noDesign 통합 페이지에 통합
```ts
//noDesignCustomPage.tsx


  //통합 페이지에서 patch에 보낼 정보들 객체로 모으기
  const customInfo = {
    customId: customId,
    size: size,
    name: name,
    demand: demand,
    viewCount: step,
  };
```
* props로 각 값들을 하나하나 넘겨줬더니 props drilling이 심해 이전 step에서 받아온 값들을 customInfo라는 하나의 객체에 넣어주고, 이 객체를 priceLayout에 prop로 넘겨준 다음, priceLayout에서 필요한 값들을 업데이트 해줬습니다.

```tsx
//PriceLayout.tsx

//필요한 값들을 update해서 객체 다시 만들기
  const updatedCustomInfo = {
    ...customInfo,
    count: count,
    isPublic: isPublic,
    isCompleted: true,
    price: 0, //price 최상단(여기 layout 컴포넌트)에서 관리할 수 있게 + 할인 로직까지 포함해서 수정 부탁해용 !!
    viewCount: step,
  };
```
* priceLayout에서 받아오는 정보들을 다시 객체에 update 시켜줍니다. priceLayout에서 쓰이는 state들은 다른 step의 컴포넌트들에서는 필요가 없어 최상단 통합 페이지로 올려주지 않았습니다.
* 🚨! pricePage = priceLayout을 제가 구현한 부분이 아니다보니 지워도 괜찮은지 확신할 수 없는 코드가 몇개 있었는데, 이 부분 주석으로 남겨 놓았으니 참고 부탁드려요 
=> isCompleted를 그냥 true로 넘겨주면 안되는지, 왜 함수로 state를 update하는 구조인지 잘 모르겠습니당 ..! 저는 isCompletee = true로 넘겨줘도 잘 떠서 일단 이렇게 구현해봤습니다
* 🚨 price 값도 로직 상 수정해야 될 부분이 있는것 같아 우선 0으로 처리해 구현했습니다! 지민 언니 통합 pr에서 반영해주세용 ~!!!

```tsx
// priceFooter.tsx

  const handleClickFooterBtn = async () => {
    const formData = new FormData();
    try {
      // 1. handDrawingImage(손 그림) append
      formData.append('handDrawingImage', handDrawingImage);

      // 2. customInfo(커스텀 정보들) append
      const json = JSON.stringify(customInfo);
      const blob = new Blob([json], { type: 'application/json' });
      formData.append('customInfo', blob);

      // 3. customImage(도안 이미지) append
      if (customImages) {
        for (let i = 0; i < customImages.length; i++) {
          formData.append('customImages', customImages.item(i) as File);
        }
      }

      const { data } = await api.patch('/custom/update', formData, {
        headers: {
          'Content-Type': 'multipart/form-data',
        },
      });
      // console.log('data', data.data, '!!!!!');
      setReceiptData(data.data);
      setStep((prev) => prev + 1);
    } catch (err) {
      console.log('Error', err);
    }
  };
```
* 받아온 customInfo, handDrawingImage, customImages를 priceFooter로 넘겨줘 patch 될 수 있도록 수정했습니다
* 🚨 handDrawingImage type이 File로 되어 있던데..! swagger에는 string으로 되어 있네용..? 한 번 확인해봐야 할것 같습니다! 제 플로우(noDesign)에서는 확인할 수 없는 부분이라 지민 언니가 통합 할 때 확인 하면 좋을것 같아요
* patch 후 response로 받은 data는 다시 통합 페이지에서 관리하는 receiptData state에 저장시키고, 통신이 완료되면 step을 하나 증가시켜 receiptPage로 넘어갈수 있게 구현했습니다

<br/>
<hr/>

###3️⃣ receiptPageg를 noDesign 통합 페이지에 통합
```tsx
//noDesignCustomPage.tsx

  // patch 통신 response = receipt 뷰에 넘겨줘야 하는 정보들
  const [receiptData, setReceiptData] = useState<resCustomInfoType>();

...


    case 4:
      return <ReceiptLayout receiptData={receiptData} />;

```
* priceFooter에서 patch 통신 후 받아온 response 정보들을  receipt 뷰에 넘겨주기 위해서 최상단 (= 통합 페이지)에서 관리하도록 했습니다

```tsx
// ReceiptDetail.tsx

  if (receiptData === undefined) return;

  const {
    size,
    count,
    isColored,
    name,
    description,
    demand,
    themes,
    styles,
    mainImageUrl,
    handDrawingImageUrl,
    images,
  } = receiptData;

  const previewURL = [...themes, ...styles];
  const imagesArray = handDrawingImageUrl
    ? [mainImageUrl, ...images, handDrawingImageUrl]
    : [mainImageUrl, ...images];
```
* 통신 후 받아온 reponse 정보들은 영수증 ui가 있는 ReceiptDetail 컴포넌트까지 props로 내려주고, early return으로 undefined type에 대한 에러를 방지 한 후 구조분해할당 해서 정보를 빼왔습니다
* 🚨 noDesign인지, haveDesign인지에 따라 영수증 뷰가 다르게 보여야 하는데 이 부분이 안된것 같습니다! 수정 부탁해용 ~!

## 😡 Trouble Shooting
- 휴~ 복잡하당
- 연결된 플로우라 초반에 커밋을 잘 쪼개지 못함

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/3e905429-f225-46b5-b080-a0d1a2bc51de

