### PR TITLE
[modal] qa 내용 반영

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -26,6 +26,7 @@ import SearchResultPage from './page/Search/SearchResultPage';
 import ScrollToTop from './libs/hooks/ScrollTop';
 import LoginCallback from './components/Login/LoginCallback';
 import SavePage from './page/SavePage';
+import ErrorPage from './page/Error/ErrorPage';
 
 const Router = () => {
   return (
@@ -60,6 +61,7 @@ const Router = () => {
         <Route path='/complete' element={<CompletePage />} />
         <Route path='/custom-reference' element={<CustomReferencePage />} />
         <Route path='/save' element={<SavePage />} />
+        <Route path='/error' element={<ErrorPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
+++ b/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
@@ -1,15 +1,20 @@
 import { styled } from 'styled-components';
-
 import { useNavigate } from 'react-router-dom';
 import useGetUserProfile from '../../../libs/hooks/useGetUserProfile';
-import { useEffect, useState } from 'react';
+import { SetStateAction, useEffect, useState } from 'react';
+import { IcCancelDark } from '../../../assets/icon';
 
 interface ChargePointCompleteModalProps {
   chargeAmount: number;
   redirectURL: string;
+  setModalOn: React.Dispatch<SetStateAction<boolean>>;
 }
 
-const ChargePointCompleteModal = ({ chargeAmount, redirectURL }: ChargePointCompleteModalProps) => {
+const ChargePointCompleteModal = ({
+  chargeAmount,
+  redirectURL,
+  setModalOn,
+}: ChargePointCompleteModalProps) => {
   const navigate = useNavigate();
   const [currPoint, setCurrPoint] = useState(0);
 
@@ -29,6 +34,7 @@ const ChargePointCompleteModal = ({ chargeAmount, redirectURL }: ChargePointComp
       <St.ModalWrapper>
         <St.ModalContent>
           <St.ModalTitleWrapper>
+            <IcCancelDark onClick={() => setModalon(false)} />
             <St.ModalTitle>포인트 충전 완료</St.ModalTitle>
           </St.ModalTitleWrapper>
 

--- a/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
+++ b/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
@@ -133,8 +133,8 @@ const St = {
     align-items: center;
     width: 29.1rem;
     height: 9.6rem;
-    margin-top: 1.5rem;
-    margin-bottom: 4rem;
+    margin-top: 2.5rem;
+    margin-bottom: 3rem;
     gap: 1.4rem;
 
     border-radius: 0.6rem;
@@ -166,7 +166,7 @@ const St = {
   TopContents: styled.p`
     color: ${({ theme }) => theme.colors.gray5};
 
-    ${({ theme }) => theme.fonts.title_semibold_18};
+    ${({ theme }) => theme.fonts.title_medium_18};
   `,
 
   BottomContents: styled.p`

--- a/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
+++ b/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
@@ -42,7 +42,7 @@ const ChargePointCompleteModal = ({
             <St.PointWrapper>
               <St.PointTitle>충전한 금액</St.PointTitle>
               <St.PointContentsWrapper>
-                <St.TopContents>{chargeAmount}</St.TopContents>
+                <St.TopContents>{chargeAmount.toLocaleString()}</St.TopContents>
                 <St.Unit>P</St.Unit>
               </St.PointContentsWrapper>
             </St.PointWrapper>
@@ -50,7 +50,7 @@ const ChargePointCompleteModal = ({
             <St.PointWrapper>
               <St.PointTitle>충전 후 포인트 잔액</St.PointTitle>
               <St.PointContentsWrapper>
-                <St.BottomContents>{currPoint}</St.BottomContents>
+                <St.BottomContents>{currPoint.toLocaleString()}</St.BottomContents>
                 <St.Unit>P</St.Unit>
               </St.PointContentsWrapper>
             </St.PointWrapper>

--- a/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
+++ b/src/common/Modal/ChargePointModal/ChargePointCompleteModal.tsx
@@ -34,7 +34,7 @@ const ChargePointCompleteModal = ({
       <St.ModalWrapper>
         <St.ModalContent>
           <St.ModalTitleWrapper>
-            <IcCancelDark onClick={() => setModalon(false)} />
+            <IcCancelDark onClick={() => setModalOn(false)} />
             <St.ModalTitle>포인트 충전 완료</St.ModalTitle>
           </St.ModalTitleWrapper>
 

--- a/src/common/Modal/ChargePointModal/ChargePointModalForm.tsx
+++ b/src/common/Modal/ChargePointModal/ChargePointModalForm.tsx
@@ -161,7 +161,7 @@ const St = {
     width: 29.1rem;
     height: 9.6rem;
     margin-top: 1.5rem;
-    margin-bottom: 4rem;
+    margin-bottom: 3rem;
     gap: 1.4rem;
 
     border-radius: 0.6rem;
@@ -193,7 +193,7 @@ const St = {
   TopContents: styled.p`
     color: ${({ theme }) => theme.colors.gray5};
 
-    ${({ theme }) => theme.fonts.title_semibold_18};
+    ${({ theme }) => theme.fonts.title_medium_18};
   `,
 
   BottomContents: styled.p<{ $isEnoughPoint: boolean }>`

--- a/src/common/Modal/ChargePointModal/ChargePointModalForm.tsx
+++ b/src/common/Modal/ChargePointModal/ChargePointModalForm.tsx
@@ -48,7 +48,7 @@ const ChargePointModalForm = ({
           },
         });
       } catch (err) {
-        // navigate("/error") //에러 처리 추가 예정
+        navigate('/error');
       }
     } else {
       navigate('/point-charge', {

--- a/src/common/Modal/CheckModal/CheckModal.tsx
+++ b/src/common/Modal/CheckModal/CheckModal.tsx
@@ -13,7 +13,8 @@ const CheckModal = ({ setModalOn, chargeAmount, setIsOpenCompleteModal }: CheckM
       <CheckModalForm
         onClose={() => setModalOn(false)}
         title={'한번 더 확인해주세요'}
-        subTitle={'정확하게 송금하지 않을 시 추후에 주문이 취소될 수 있어요'}
+        subTitle={'정확하게 송금하지 않을 시'}
+        subTitle_2={'추후에 주문이 취소될 수 있어요'}
         continueBtn={'확인했어요'}
         chargeAmount={chargeAmount}
         setIsOpenCompleteModal={setIsOpenCompleteModal}

--- a/src/common/Modal/CheckModal/CheckModal.tsx
+++ b/src/common/Modal/CheckModal/CheckModal.tsx
@@ -14,7 +14,7 @@ const CheckModal = ({ setModalOn, chargeAmount, setIsOpenCompleteModal }: CheckM
         onClose={() => setModalOn(false)}
         title={'한번 더 확인해주세요'}
         subTitle={'정확하게 송금하지 않을 시'}
-        subTitle_2={'추후에 주문이 취소될 수 있어요'}
+        subTitle2={'추후에 주문이 취소될 수 있어요'}
         continueBtn={'확인했어요'}
         chargeAmount={chargeAmount}
         setIsOpenCompleteModal={setIsOpenCompleteModal}

--- a/src/common/Modal/CheckModal/CheckModalForm.tsx
+++ b/src/common/Modal/CheckModal/CheckModalForm.tsx
@@ -7,7 +7,7 @@ interface CheckModalFormProps {
   onClose: () => void;
   title: string;
   subTitle: string;
-  subTitle_2: string;
+  subTitle2: string;
   continueBtn: string;
   chargeAmount: number;
   setIsOpenCompleteModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -17,7 +17,7 @@ const CheckModalForm = ({
   onClose,
   title,
   subTitle,
-  subTitle_2,
+  subTitle2,
   continueBtn,
   chargeAmount,
   setIsOpenCompleteModal,
@@ -43,7 +43,7 @@ const CheckModalForm = ({
           <IcCancelDark onClick={onClose} />
           <St.ModalTitle>{title}</St.ModalTitle>
           <St.ModalSubTitle>{subTitle}</St.ModalSubTitle>
-          <St.ModalSubTitle>{subTitle_2}</St.ModalSubTitle>
+          <St.ModalSubTitle>{subTitle2}</St.ModalSubTitle>
         </St.ModalTitleWrapper>
 
         <St.BtnWrapper>

--- a/src/common/Modal/CheckModal/CheckModalForm.tsx
+++ b/src/common/Modal/CheckModal/CheckModalForm.tsx
@@ -7,6 +7,7 @@ interface CheckModalFormProps {
   onClose: () => void;
   title: string;
   subTitle: string;
+  subTitle_2: string;
   continueBtn: string;
   chargeAmount: number;
   setIsOpenCompleteModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -16,6 +17,7 @@ const CheckModalForm = ({
   onClose,
   title,
   subTitle,
+  subTitle_2,
   continueBtn,
   chargeAmount,
   setIsOpenCompleteModal,
@@ -41,6 +43,7 @@ const CheckModalForm = ({
           <IcCancelDark onClick={onClose} />
           <St.ModalTitle>{title}</St.ModalTitle>
           <St.ModalSubTitle>{subTitle}</St.ModalSubTitle>
+          <St.ModalSubTitle>{subTitle_2}</St.ModalSubTitle>
         </St.ModalTitleWrapper>
 
         <St.BtnWrapper>
@@ -71,6 +74,7 @@ const St = {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+
     position: relative;
     width: 33.5rem;
     height: 24.1rem;
@@ -95,14 +99,14 @@ const St = {
   `,
 
   ModalTitle: styled.h2`
+    margin-bottom: 1.4rem;
+
     color: ${({ theme }) => theme.colors.gray7};
 
     ${({ theme }) => theme.fonts.title_semibold_20};
   `,
 
   ModalSubTitle: styled.p`
-    padding: 1.6rem 7.25rem 4rem 7.25rem;
-
     text-align: center;
     color: ${({ theme }) => theme.colors.gray3};
 
@@ -125,6 +129,7 @@ const St = {
     align-items: center;
     width: 100%;
     height: 7rem;
+    margin-top: 4rem;
 
     border-bottom-left-radius: 1rem;
     border-bottom-right-radius: 1rem;

--- a/src/common/Modal/CheckModal/CheckModalForm.tsx
+++ b/src/common/Modal/CheckModal/CheckModalForm.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { IcCancelDark } from '../../../assets/icon';
-
+import { useNavigate } from 'react-router-dom';
 import api from '../../../libs/api';
 
 interface CheckModalFormProps {
@@ -20,6 +20,7 @@ const CheckModalForm = ({
   chargeAmount,
   setIsOpenCompleteModal,
 }: CheckModalFormProps) => {
+  const navigate = useNavigate();
   const handleClickContinueBtn = async () => {
     //포인트 충전
     try {
@@ -28,10 +29,8 @@ const CheckModalForm = ({
       });
       setIsOpenCompleteModal(true);
       onClose();
-      // navigate(redirectURL);
     } catch (err) {
-      // console.log(err); //추후 삭제 예정(에러 페이지 라우팅 하면)
-      // navigate("/error")
+      navigate('/error');
     }
   };
 

--- a/src/common/Modal/EscapeModal/ChargePointEscapeModal.tsx
+++ b/src/common/Modal/EscapeModal/ChargePointEscapeModal.tsx
@@ -15,7 +15,7 @@ const ChargePointEscapeModal = ({ setModalOn, redirectURL }: ChargePointEscapeMo
         pageName={'ChargePage'}
         title={'정말 그만두시나요?'}
         subTitle={'지금 그만두시면 포인트 충전을'}
-        subTitle_2={'처음부터 다시 진행해야 해요'}
+        subTitle2={'처음부터 다시 진행해야 해요'}
         continueBtn={'계속하기'}
         stopBtn={'그만하기'}
       />

--- a/src/common/Modal/EscapeModal/ChargePointEscapeModal.tsx
+++ b/src/common/Modal/EscapeModal/ChargePointEscapeModal.tsx
@@ -14,7 +14,8 @@ const ChargePointEscapeModal = ({ setModalOn, redirectURL }: ChargePointEscapeMo
         onClose={() => setModalOn(false)}
         pageName={'ChargePage'}
         title={'정말 그만두시나요?'}
-        subTitle={'지금 그만두시면 포인트 충전을 처음부터 다시 진행해야 해요'}
+        subTitle={'지금 그만두시면 포인트 충전을'}
+        subTitle_2={'처음부터 다시 진행해야 해요'}
         continueBtn={'계속하기'}
         stopBtn={'그만하기'}
       />

--- a/src/common/Modal/EscapeModal/EscapeModalForm.tsx
+++ b/src/common/Modal/EscapeModal/EscapeModalForm.tsx
@@ -9,7 +9,7 @@ interface EscapeModalFormProps {
   pageName: string;
   title: string;
   subTitle: string;
-  subTitle_2: string;
+  subTitle2: string;
   continueBtn: string;
   stopBtn: string;
 }
@@ -20,7 +20,7 @@ const EscapeModalForm = ({
   pageName,
   title,
   subTitle,
-  subTitle_2,
+  subTitle2,
   continueBtn,
   stopBtn,
 }: EscapeModalFormProps) => {
@@ -56,7 +56,7 @@ const EscapeModalForm = ({
           <IcCancelDark onClick={onClose} />
           <St.ModalTitle>{title}</St.ModalTitle>
           <St.ModalSubTitle>{subTitle}</St.ModalSubTitle>
-          <St.ModalSubTitle>{subTitle_2}</St.ModalSubTitle>
+          <St.ModalSubTitle>{subTitle2}</St.ModalSubTitle>
         </St.ModalTitleWrapper>
 
         <St.BtnWrapper>

--- a/src/common/Modal/EscapeModal/EscapeModalForm.tsx
+++ b/src/common/Modal/EscapeModal/EscapeModalForm.tsx
@@ -9,6 +9,7 @@ interface EscapeModalFormProps {
   pageName: string;
   title: string;
   subTitle: string;
+  subTitle_2: string;
   continueBtn: string;
   stopBtn: string;
 }
@@ -19,6 +20,7 @@ const EscapeModalForm = ({
   pageName,
   title,
   subTitle,
+  subTitle_2,
   continueBtn,
   stopBtn,
 }: EscapeModalFormProps) => {
@@ -54,6 +56,7 @@ const EscapeModalForm = ({
           <IcCancelDark onClick={onClose} />
           <St.ModalTitle>{title}</St.ModalTitle>
           <St.ModalSubTitle>{subTitle}</St.ModalSubTitle>
+          <St.ModalSubTitle>{subTitle_2}</St.ModalSubTitle>
         </St.ModalTitleWrapper>
 
         <St.BtnWrapper>
@@ -99,7 +102,7 @@ const St = {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    margin-top: 4.7rem;
+    margin-top: 4.9rem;
 
     & > svg {
       position: absolute;
@@ -109,14 +112,13 @@ const St = {
   `,
 
   ModalTitle: styled.h2`
+    margin-bottom: 1.4rem;
     color: ${({ theme }) => theme.colors.gray7};
 
     ${({ theme }) => theme.fonts.title_semibold_20};
   `,
 
   ModalSubTitle: styled.p`
-    padding: 1.6rem 2.6rem 4rem 2.6rem;
-
     text-align: center;
     color: ${({ theme }) => theme.colors.gray3};
 
@@ -133,6 +135,7 @@ const St = {
     align-items: flex-end;
     width: 100%;
     padding: 0;
+    margin-top: 4rem;
   `,
 
   ContinueBtn: styled.button`

--- a/src/common/Modal/EscapeModal/LoginEscapeModal.tsx
+++ b/src/common/Modal/EscapeModal/LoginEscapeModal.tsx
@@ -12,7 +12,8 @@ const LoginEscapeModal = ({ setModalOn }: LoginEscapeModalProps) => {
         onClose={() => setModalOn(false)}
         pageName={'LoginPage'}
         title={'정말 그만두시나요?'}
-        subTitle={'지금 그만두시면 회원가입을 처음부터 다시 진행해야 해요'}
+        subTitle={'지금 그만두시면 회원가입을'}
+        subTitle_2={'처음부터 다시 진행해야 해요'}
         continueBtn={'계속하기'}
         stopBtn={'그만하기'}
       />

--- a/src/common/Modal/EscapeModal/LoginEscapeModal.tsx
+++ b/src/common/Modal/EscapeModal/LoginEscapeModal.tsx
@@ -13,7 +13,7 @@ const LoginEscapeModal = ({ setModalOn }: LoginEscapeModalProps) => {
         pageName={'LoginPage'}
         title={'정말 그만두시나요?'}
         subTitle={'지금 그만두시면 회원가입을'}
-        subTitle_2={'처음부터 다시 진행해야 해요'}
+        subTitle2={'처음부터 다시 진행해야 해요'}
         continueBtn={'계속하기'}
         stopBtn={'그만하기'}
       />

--- a/src/common/Modal/WelcomeModal/WelcomeModalForm.tsx
+++ b/src/common/Modal/WelcomeModal/WelcomeModalForm.tsx
@@ -96,10 +96,7 @@ const St = {
   `,
 
   BtnWrapper: styled.div`
-    display: flex;
-    align-items: flex-end;
     width: 100%;
-    padding: 0;
   `,
 
   ContinueBtn: styled.button`

--- a/src/common/PreventAccess/PreventAccess.tsx
+++ b/src/common/PreventAccess/PreventAccess.tsx
@@ -13,7 +13,7 @@ const PreventAccess = ({ title, btnContents, isError }: PreventAccessProps) => {
   const navigate = useNavigate();
 
   const handleClickButton = () => {
-    isError ? window.location.reload() : navigate('/');
+    isError ? navigate(-1) : navigate('/');
   };
 
   return (

--- a/src/components/PointCharge/PointTransferFooter.tsx
+++ b/src/components/PointCharge/PointTransferFooter.tsx
@@ -35,7 +35,7 @@ const PointTransferFooter = ({
         />
       )}
       {isOpenCompleteModal && (
-        <ChargePointCompleteModal chargeAmount={chargeAmount} redirectURL={redirectURL} />
+        <ChargePointCompleteModal setModalOn={setModalOn} chargeAmount={chargeAmount} redirectURL={redirectURL} />
       )}
     </>
   );

--- a/src/components/PointCharge/PointTransferFooter.tsx
+++ b/src/components/PointCharge/PointTransferFooter.tsx
@@ -35,7 +35,11 @@ const PointTransferFooter = ({
         />
       )}
       {isOpenCompleteModal && (
-        <ChargePointCompleteModal setModalOn={setModalOn} chargeAmount={chargeAmount} redirectURL={redirectURL} />
+        <ChargePointCompleteModal
+          setModalOn={setIsOpenCompletModal}
+          chargeAmount={chargeAmount}
+          redirectURL={redirectURL}
+        />
       )}
     </>
   );

--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 import React, { SetStateAction, useReducer, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import api from '../../libs/api';
 import { reducer } from '../../libs/reducers/registerReducer';
@@ -26,6 +26,7 @@ interface usePatchProfileProps {
 }
 
 const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
+  const navigate = useNavigate();
   const MINUTES_IN_MS = 5 * 60 * 1000;
   const [toast, setToast] = useState(false);
   const [isTimeout, setIsTimeout] = useState(false);
@@ -58,8 +59,8 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
       .then(() => {
         setStep(3);
       })
-      .catch((Error: object) => {
-        console.log(Error);
+      .catch(() => {
+        navigate('/error');
       });
   };
 
@@ -101,8 +102,8 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
           setToast(true);
           setIsTimeout(false);
         })
-        .catch((Error: object) => {
-          console.log(Error);
+        .catch(() => {
+          navigate('/error');
         });
     }
     dispatch({ type: 'HIDE_CERTIFICATION_FORM' });
@@ -139,8 +140,8 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
             dispatch({ type: 'VERIFIED_FAILED' });
           }
         })
-        .catch((Error: object) => {
-          console.log(Error);
+        .catch(() => {
+          navigate('/error');
         });
     } else {
       dispatch({ type: 'VERIFIED_NOT_FAILED' });

--- a/src/libs/hooks/useKakaoLogin.tsx
+++ b/src/libs/hooks/useKakaoLogin.tsx
@@ -40,8 +40,8 @@ const useKakaoLogin = () => {
 
           isUserExist ? navigate('/') : navigate('/login', { state: { step: 1 } });
         })
-        .catch((Error: object) => {
-          console.log(Error);
+        .catch(() => {
+          navigate('/error');
         });
     }
   }, []);


### PR DESCRIPTION
## 🔥 Related Issues
resolved #504 

## 💜 작업 내용
- [x] qa 내용 반영

## ✅ PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
    - 아래 명시하지 않은 이슈는 단순 css 수정으로 해결했습니다! (코드 한 번씩 확인 부탁드려용)
    - 에러페이지 라우팅 `/error` 로 접근 가능
    
    <br />
    
    - 모달 내용 줄바꿈 애매하게 되는 이슈
       <img width="558" alt="스크린샷 2023-08-20 오전 2 39 47" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/be9e13d8-6cb1-4646-be88-a3158ec91d8b">
        - subTitle을 2개로 나눈 뒤, css 수정하여 해결
        
        ```tsx
        // common > Modal > CheckModal > CheckModal.tsx
        subTitle={'정확하게 송금하지 않을 시'}
        subTitle_2={'추후에 주문이 취소될 수 있어요'}
        ```
        
        ```tsx
        // common > Modal > CheckModal > CheckModalForm.tsx
        <St.ModalSubTitle>{subTitle}</St.ModalSubTitle>
        <St.ModalSubTitle>{subTitle_2}</St.ModalSubTitle>
        ```
        
        <br />
        
    - 모달 양 옆 마진 넓어보이는 이슈
        <img width="512" alt="스크린샷 2023-08-20 오후 2 05 13" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/9ac4d794-3b84-441e-bf6b-747d01bfb25d">
        - 모달 크기를 고정해서 발생하는 이슈로, 오히려 크기가 아닌 양 옆 마진을 고정할 경우 모달 크기가 화면 max-width 보다 커지는 이슈가 발생하여 디자인과 상의 후 기존 방식(모달 크기 고정) 그대로 가져가기로 함

    
    <br />
    
    - `X` 아이콘 빠져있는 이슈
        <img width="882" alt="스크린샷 2023-08-20 오후 2 08 23" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/82ed6294-fe06-4dfb-87c4-d52ca133b99a">
        - 모달을 컨트롤할 수 있는 `setIsOpenCompletModal`을 props로 전달
        
        ```tsx
        // ChargePointCompleteModal.tsx
        <ChargePointCompleteModal
            setModalOn={setIsOpenCompletModal}
            chargeAmount={chargeAmount}
            redirectURL={redirectURL}
        />
        ```
        
        - x 버튼 클릭 시, `setModalOn`의 값을 `false`로 만들어 모달이 화면에서 사라지게 함
    
    <br />
    
    - 모달 내부 금액에 콤마 표시되지 않는 이슈
        <img width="882" alt="스크린샷 2023-08-20 오후 2 08 23" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/82ed6294-fe06-4dfb-87c4-d52ca133b99a">
        - `toLocaleString()` 메소드 활용하여 해결
        
        ```tsx
        // ChargePointCompleteModal.tsx
        <St.PointTitle>충전한 금액</St.PointTitle>
          <St.PointContentsWrapper>
            <St.TopContents>{chargeAmount.toLocaleString()}</St.TopContents>
            <St.Unit>P</St.Unit>
          </St.PointContentsWrapper>
        </St.PointWrapper>
        
        <St.PointWrapper>
          <St.PointTitle>충전 후 포인트 잔액</St.PointTitle>
          <St.PointContentsWrapper>
            <St.BottomContents>{currPoint.toLocaleString()}</St.BottomContents>
            <St.Unit>P</St.Unit>
          </St.PointContentsWrapper>
        ```
        
    
    <br />
    
    - 가입 축하 포인트 지급 모달의 하단 버튼 옆에 알 수 없는 흰색 선이 생기는 이슈
        <img width="314" alt="스크린샷 2023-08-20 오후 3 42 53" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/800be0b3-513e-43ca-ba9a-ab60ff22edef">
        - 일단 없어도 되는 css 코드를 발견하여 삭제함
        - 해당 이슈가 데탑에서는 발견되지 않아서 코드수정 후 이슈가 해결됐는지 여부를 확인하지 못함
        - 배포 후 확인 예정 → 수정되지 않았다면 다시 리팩토링

<br />
