### PR TITLE
[modal] qa 반영 2차 리팩토링

### DIFF
--- a/src/common/Modal/WelcomeModal/WelcomeModalForm.tsx
+++ b/src/common/Modal/WelcomeModal/WelcomeModalForm.tsx
@@ -19,12 +19,14 @@ const WelcomeModalForm = ({ onClose, title, continueBtn }: WelcomeModalFormProps
   return (
     <St.ModalContainer>
       <St.ModalContent>
-        <St.ModalTitleWrapper>
-          <IcCancelDark onClick={onClose} />
-          <St.ModalTitle>{title}</St.ModalTitle>
-        </St.ModalTitleWrapper>
+        <St.Contents>
+          <St.ModalTitleWrapper>
+            <IcCancelDark onClick={onClose} />
+            <St.ModalTitle>{title}</St.ModalTitle>
+          </St.ModalTitleWrapper>
 
-        <ImgPointCoupon />
+          <ImgPointCoupon />
+        </St.Contents>
 
         <St.BtnWrapper>
           <St.ContinueBtn onClick={handleClickContinueBtn}>{continueBtn}</St.ContinueBtn>
@@ -56,10 +58,18 @@ const St = {
     align-items: center;
     position: relative;
     width: 33.5rem;
-    height: 41.8rem;
+  `,
 
-    border-radius: 1rem;
+  Contents: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    height: 34.8rem;
 
+    border-top-right-radius: 1rem;
+    border-top-left-radius: 1rem;
+    
     background-color: ${({ theme }) => theme.colors.white};
   `,
 
@@ -103,7 +113,6 @@ const St = {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-top: 4rem;
     width: 100%;
     height: 7rem;
 


### PR DESCRIPTION
## 🔥 Related Issues
Closed #504 

## 💜 작업 내용
- [x] 가입 환영 포인트 지급 모달 하단 버튼 사이드에 흰색 줄 생기는 이슈 해결

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
    - 하단 버튼과 모달 내용을 전부 포함하는 영역(`ModalContent`)이 흰 배경을 가지고 있음
    - `예상 원인`: 이로 인해 버튼 사이드 간격이 조금이라도 맞지 않을 경우 뒷 배경이 보이게 된다고 파악
    - 버튼과 모달 내용을 모두 포함하는 영역(`ModalContent`)은 배경 색을 갖게 않게 수정
    - 모달 내용을 감싸는 영역(`Contents`)을 하나 추가하여 이 부분이 흰 배경을 갖도록 함
    ```
    <St.ModalContent>
        <St.Contents>
          <St.ModalTitleWrapper>
            <IcCancelDark onClick={onClose} />
            <St.ModalTitle>{title}</St.ModalTitle>
          </St.ModalTitleWrapper>

          <ImgPointCoupon />
        </St.Contents>

        <St.BtnWrapper>
          <St.ContinueBtn onClick={handleClickContinueBtn}>{continueBtn}</St.ContinueBtn>
        </St.BtnWrapper>
      </St.ModalContent>
      ```

## 😡 Trouble Shooting
- 원인 파악을 하는 과정이 지끈지끈 했지만 리댜숭의 도움으로 예상되는 원인을 찾았슴돠 (리댜숭 감솨...🖤)
- 코드를 수정함에 따라 해당 이슈가 해결된 듯 하지만, 배포 후 모바일로 봐야 정확히 알 수 있을 듯 합니다

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="355" alt="스크린샷 2023-08-21 오전 12 29 36" src="https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/b474430c-5a27-42d3-8ad1-d147ccf838c6">

