### PR TITLE
[SP1] 장바구니 삭제 모달 추가

### DIFF
--- a/src/common/Modal/DeleteCartModal/DeleteCartModal.tsx
+++ b/src/common/Modal/DeleteCartModal/DeleteCartModal.tsx
@@ -1,0 +1,24 @@
+import ModalPortal from '../ModalPortal';
+import EscapeModalForm from '../EscapeModal/EscapeModalForm';
+
+interface DeleteCartModalProps {
+  setModalOn: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const DeleteCartModal = ({ setModalOn }: DeleteCartModalProps) => {
+  return (
+    <ModalPortal>
+      <EscapeModalForm
+        onClose={() => setModalOn(false)}
+        pageName={'CartPage'}
+        title={'선택한 상품을 삭제하시나요?'}
+        subTitle={'삭제하시면 결제 대상에서'}
+        subTitle2={'해당 상품이 제외돼요'}
+        continueBtn={'삭제하기'}
+        stopBtn={'그만하기'}
+      />
+    </ModalPortal>
+  );
+};
+
+export default DeleteCartModal;

--- a/src/common/Modal/EscapeModal/EscapeModalForm.tsx
+++ b/src/common/Modal/EscapeModal/EscapeModalForm.tsx
@@ -26,10 +26,21 @@ const EscapeModalForm = ({
 }: EscapeModalFormProps) => {
   const navigate = useNavigate();
 
+  const handleClickContinueBtn = () => {
+    onClose();
+    switch (pageName) {
+      case 'CartPage':
+        // 아이템 삭제 로직 추가
+        break;
+
+      default:
+        break;
+    }
+  };
+
   const handleClickStopBtn = () => {
     onClose();
     switch (pageName) {
-      // 페이지 이름과 라우팅 주소는 나중에 보고 수정
       case 'LoginPage':
         navigate('/');
         removeAccessToken();
@@ -41,6 +52,10 @@ const EscapeModalForm = ({
 
       case 'CustomSizePage':
         navigate('/onboarding');
+        break;
+
+      case 'CartPage':
+        navigate('/cart');
         break;
 
       default:
@@ -60,7 +75,7 @@ const EscapeModalForm = ({
         </St.ModalTitleWrapper>
 
         <St.BtnWrapper>
-          <St.ContinueBtn onClick={onClose}>{continueBtn}</St.ContinueBtn>
+          <St.ContinueBtn onClick={handleClickContinueBtn}>{continueBtn}</St.ContinueBtn>
           <St.StopBtn onClick={handleClickStopBtn}>{stopBtn}</St.StopBtn>
         </St.BtnWrapper>
       </St.ModalContent>

--- a/src/components/Cart/CartBottom.tsx
+++ b/src/components/Cart/CartBottom.tsx
@@ -24,6 +24,8 @@ const St = {
     color: ${({ theme }) => theme.colors.gray8};
   `,
   LightBorder: styled.hr`
+    width: 100%;
+    max-width: 43rem;
     height: 1.3rem;
     border: none;
     background-color: ${({ theme }) => theme.colors.gray0};
@@ -33,6 +35,7 @@ const St = {
     position: fixed;
     bottom: 7rem;
     width: 100%;
+    max-width: 43rem;
   `,
 };
 

--- a/src/components/Cart/CartFooter.tsx
+++ b/src/components/Cart/CartFooter.tsx
@@ -22,6 +22,7 @@ const St = {
     position: fixed;
     bottom: 0;
     width: 100%;
+    max-width: 43rem;
     height: 7rem;
   `,
 

--- a/src/components/Cart/CartItem.tsx
+++ b/src/components/Cart/CartItem.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 import { IcCancelDark, IcMinus, IcMinusOneunder, IcPlus } from '../../assets/icon';
 import { useState } from 'react';
+import DeleteCartModal from '../../common/Modal/DeleteCartModal/DeleteCartModal';
+
 const CartItem = ({ id, name, price, originalPrice }) => {
   const [count, setCount] = useState(1);
+  const [modalOn, setModalOn] = useState(false);
 
   return (
     <St.Item>
@@ -19,7 +22,8 @@ const CartItem = ({ id, name, price, originalPrice }) => {
         </St.TitleSection>
       </St.ItemInformation>
       <St.ButtonSection>
-        <IcCancelDark />
+        <IcCancelDark onClick={() => setModalOn(true)} />
+        {modalOn && <DeleteCartModal setModalOn={setModalOn} />}
         <St.Stepper>
           {count === 1 ? (
             <IcMinusOneunder />


### PR DESCRIPTION
## 🔥 Related Issues
resolved #551 

## 💜 작업 내용
- [x] 장바구니 삭제 모달 추가
- [x] 장바구니 페이지 푸터/ 하단 부분 너비 안 맞는 이슈 해결

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - 장바구니 삭제 모달을 추가했습니다.
  - ModalForm은 기존에 있던 EscapeModalForm.tsx를 활용했습니다.
  ```typescript
      <ModalPortal>
      <EscapeModalForm
        onClose={() => setModalOn(false)}
        pageName={'CartPage'}
        title={'선택한 상품을 삭제하시나요?'}
        subTitle={'삭제하시면 결제 대상에서'}
        subTitle2={'해당 상품이 제외돼요'}
        continueBtn={'삭제하기'}
        stopBtn={'그만하기'}
      />
    </ModalPortal>
  ```
  
  - 너비가 제대로 적용되지 않는 이슈는 max-width를 적용하여 해결했습니다.
  ```css
    width: 100%;
    max-width: 43rem;
  ```

## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지
  - 모달에서 삭제하기를 누르면 아이템이 삭제되도록 하려고 했는데, 일단은 더미데이터로 들어가 있어서 그 부분까진 구현하지 않았고 추후 구현을 위해 큰 틀만 잡아놨습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/b8dcb5c9-35bd-421b-a3f7-daf387de6c2f

