### PR TITLE
[SP1/Custom] 커스텀 신청시 포인트 충전 모달 삭제, 커스텀 신청 api 연결

### DIFF
--- a/src/components/Custom/Common/OnBoardingFooter.tsx
+++ b/src/components/Custom/Common/OnBoardingFooter.tsx
@@ -66,7 +66,7 @@ const OnBoardingFooter = ({ isLogin }: { isLogin: boolean }) => {
     !loading && (
       <>
         <St.OnBoardingFooter onClick={handleClickFooter}>
-          <St.FooterText>990P 내고 신청서 작성하기</St.FooterText>
+          <St.FooterText>신청서 작성하기</St.FooterText>
         </St.OnBoardingFooter>
         {isModalOpen && modalOn && <TempSaveModal setModalOn={setModalOn} />}
       </>

--- a/src/components/Custom/Common/Select/SelectCustomFooter.tsx
+++ b/src/components/Custom/Common/Select/SelectCustomFooter.tsx
@@ -1,9 +1,5 @@
 import { styled } from 'styled-components';
-import api from '../../../../libs/api';
-import { useNavigate } from 'react-router-dom';
 import usePostCustomApply from '../../../../libs/hooks/usePostCustomApply';
-// import ChargePointModal from '../../../../common/Modal/ChargePointModal/ChargePointModal';
-// import React, { useState } from 'react';
 
 interface SelectCustomFooterProps {
   isActiveNext: boolean;

--- a/src/components/Custom/Common/Select/SelectCustomFooter.tsx
+++ b/src/components/Custom/Common/Select/SelectCustomFooter.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import api from '../../../../libs/api';
 import { useNavigate } from 'react-router-dom';
+import usePostCustomApply from '../../../../libs/hooks/usePostCustomApply';
 // import ChargePointModal from '../../../../common/Modal/ChargePointModal/ChargePointModal';
 // import React, { useState } from 'react';
 
@@ -17,23 +18,15 @@ const SelectCustomFooter = ({
   setStep,
   setCustomId,
 }: SelectCustomFooterProps) => {
-  const navigate = useNavigate();
-
-  const postCustomApply = async () => {
-    try {
-      const { data } = await api.post('/custom/apply', {
-        haveDesign: haveDesign,
-      });
-      setCustomId(data.data.customId);
-    } catch (err) {
-      navigate('/error');
-    }
-  };
+  const { response } = usePostCustomApply(haveDesign);
 
   const handleClickFooter = () => {
     if (!isActiveNext) return;
-    postCustomApply();
-    setStep((prev) => prev + 1);
+
+    if (response) {
+      setCustomId(response.customId);
+      setStep((prev) => prev + 1);
+    }
   };
 
   return (

--- a/src/components/Custom/Common/Select/SelectCustomFooter.tsx
+++ b/src/components/Custom/Common/Select/SelectCustomFooter.tsx
@@ -1,4 +1,6 @@
 import { styled } from 'styled-components';
+import api from '../../../../libs/api';
+import { useNavigate } from 'react-router-dom';
 // import ChargePointModal from '../../../../common/Modal/ChargePointModal/ChargePointModal';
 // import React, { useState } from 'react';
 
@@ -11,31 +13,33 @@ interface SelectCustomFooterProps {
 
 const SelectCustomFooter = ({
   isActiveNext,
-  // haveDesign,
-  // setStep,
-  // setCustomId,
+  haveDesign,
+  setStep,
+  setCustomId,
 }: SelectCustomFooterProps) => {
-  // const [modalOn, setModalOn] = useState(false);
+  const navigate = useNavigate();
+
+  const postCustomApply = async () => {
+    try {
+      const { data } = await api.post('/custom/apply', {
+        haveDesign: haveDesign,
+      });
+      setCustomId(data.data.customId);
+    } catch (err) {
+      navigate('/error');
+    }
+  };
 
   const handleClickFooter = () => {
     if (!isActiveNext) return;
-    // setModalOn(true);
+    postCustomApply();
+    setStep((prev) => prev + 1);
   };
 
   return (
-    <>
-      <St.SelectCustomFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
-        <St.FooterText>다음</St.FooterText>
-      </St.SelectCustomFooter>
-      {/* {modalOn && (
-        <ChargePointModal
-          setModalOn={setModalOn}
-          haveDesign={haveDesign}
-          setStep={setStep}
-          setCustomId={setCustomId}
-        />
-      )} */}
-    </>
+    <St.SelectCustomFooter $isActiveNext={isActiveNext} onClick={handleClickFooter}>
+      <St.FooterText>다음</St.FooterText>
+    </St.SelectCustomFooter>
   );
 };
 

--- a/src/libs/hooks/usePostCustomApply.ts
+++ b/src/libs/hooks/usePostCustomApply.ts
@@ -1,0 +1,47 @@
+import { AxiosError, isAxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+import api from '../api';
+import { useNavigate } from 'react-router-dom';
+
+interface CustomApplyResponseData {
+  customId: number;
+}
+
+interface CustomApplyResponse {
+  data: CustomApplyResponseData;
+  code: number;
+  message: string;
+}
+
+const usePostCustomApply = (haveDesign: boolean) => {
+  const navigate = useNavigate();
+
+  const [response, setResponse] = useState<CustomApplyResponseData>();
+  const [error, setError] = useState<AxiosError>();
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = async () => {
+    try {
+      const { data } = await api.post('/custom/apply', {
+        haveDesign: haveDesign,
+      });
+      console.log(data.data);
+      setResponse(data.data);
+    } catch (err) {
+      if (isAxiosError(err)) {
+        setError(err);
+        navigate('/error');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return { response, error, loading };
+};
+
+export default usePostCustomApply;

--- a/src/libs/hooks/usePostCustomApply.ts
+++ b/src/libs/hooks/usePostCustomApply.ts
@@ -25,7 +25,6 @@ const usePostCustomApply = (haveDesign: boolean) => {
       const { data } = await api.post('/custom/apply', {
         haveDesign: haveDesign,
       });
-      console.log(data.data);
       setResponse(data.data);
     } catch (err) {
       if (isAxiosError(err)) {

--- a/src/page/Custom/Common/CommonCustomPage.tsx
+++ b/src/page/Custom/Common/CommonCustomPage.tsx
@@ -15,7 +15,6 @@ const CommonCustomPage = () => {
   const [customId, setCustomId] = useState<number>(
     state && state.customId !== undefined ? state.customId : 0,
   );
-  console.log('customId', customId);
 
   // step 1: SizePage - 선택한 타투 스티거 사이즈 state
   const [size, setSize] = useState('');


### PR DESCRIPTION
## 🔥 Related Issues
resolved #571 

## 💜 작업 내용
- [x]  커스텀 신청시 포인트 충전 모달 삭제
- [x] 포인트 신청 api 연결
- [ ] '990원 내고 ~' 온보딩 -> 상황 선택 연결 footer 워딩 수정 -> 수정 되면 바로 반영하고 머지할게요

## ✅ PR Point
- 기존에 포인트 충전 모달에서 이루어지던 커스텀 신청 api ('custom/apply')를 상황 선택 -> 사이즈 선택을 연결해주는 footer로 이동시켰습니다.
- usePostCustomApply 커스텀 훅을 만들어서 연결시켰습니다
```tsx
import { AxiosError, isAxiosError } from 'axios';
import { useEffect, useState } from 'react';
import api from '../api';
import { useNavigate } from 'react-router-dom';

interface CustomApplyResponseData {
  customId: number;
}

interface CustomApplyResponse {
  data: CustomApplyResponseData;
  code: number;
  message: string;
}

const usePostCustomApply = (haveDesign: boolean) => {
  const navigate = useNavigate();

  const [response, setResponse] = useState<CustomApplyResponseData>();
  const [error, setError] = useState<AxiosError>();
  const [loading, setLoading] = useState(true);

  const fetchData = async () => {
    try {
      const { data } = await api.post('/custom/apply', {
        haveDesign: haveDesign,
      });
      console.log(data.data);
      setResponse(data.data);
    } catch (err) {
      if (isAxiosError(err)) {
        setError(err);
        navigate('/error');
      }
    } finally {
      setLoading(false);
    }
  };

  useEffect(() => {
    fetchData();
  }, []);

  return { response, error, loading };
};

export default usePostCustomApply;

```

## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/77691829/8cfff70e-d4b8-4520-8162-2c2ed0496568

-> 콘솔에 customId 잘 찍히는걸 볼 수 있습니당~

