### PR TITLE
[SP1] 장바구니 추가 토스트 구현 

### DIFF
--- a/src/components/Detail/DetailBottom.tsx
+++ b/src/components/Detail/DetailBottom.tsx
@@ -12,6 +12,7 @@ interface DetailBottomProps {
   setLike: React.Dispatch<React.SetStateAction<boolean | null>>;
   discountPrice: number;
   shippingCost: number;
+  setCartToast: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const DetailBottom = ({
@@ -22,6 +23,7 @@ const DetailBottom = ({
   setLike,
   discountPrice,
   shippingCost,
+  setCartToast,
 }: DetailBottomProps) => {
   const [count, setCount] = useState(1);
 
@@ -77,6 +79,7 @@ const DetailBottom = ({
             setLike={setLike}
             count={count} // API연결 시 필요해서 전달
             shippingFee={3000} // 배송비도 여기에 추가하기
+            setCartToast={setCartToast}
           />
         </Sheet.Content>
       </Sheet.Container>

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -55,8 +55,7 @@ const DetailFooter = ({
         count: count,
       })
       .then(() => {
-        console.log('카트에 잘 담김');
-        //setCartToast(true); 이부분 문제
+        setCartToast(true);
         setSheetOpen(false);
       })
       .catch((err) => {
@@ -82,7 +81,6 @@ const DetailFooter = ({
     await api
       .delete(`/user/productliked/sticker/${id}/delete`)
       .then(() => {
-        // setResponse(res.data.data);
         // 좋아요 삭제
         console.log('좋아요 삭제');
       })

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -25,6 +25,7 @@ const DetailFooter = ({
 }: DetailFooterProp) => {
   const navigate = useNavigate();
   const [toast, setToast] = useState(false);
+  const [cartToast, setCartToast] = useState(false);
 
   const handleClickButton = () => {
     if (like === null) {
@@ -53,7 +54,9 @@ const DetailFooter = ({
         count: count,
       })
       // 성공 시 navigate
-      .then(() => console.log('카트에 추가 성공'))
+      .then(() => {
+        console.log('카트에 추가 성공');
+      })
       .catch((err) => {
         console.log(err);
         navigate('/error');

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -56,6 +56,7 @@ const DetailFooter = ({
       // 성공 시 navigate
       .then(() => {
         console.log('카트에 추가 성공');
+        setCartToast(true);
       })
       .catch((err) => {
         console.log(err);
@@ -127,6 +128,7 @@ const DetailFooter = ({
       <St.Line />
       <St.Like onClick={handleClickLike}>{like ? <IcHeartLight /> : <IcHeartDark />}</St.Like>
       {toast && <Toast setToast={setToast} text='로그인이 필요합니다.' />}
+      {cartToast && <Toast setToast={setCartToast} text='장바구니에 상품이 담겼습니다' />}
     </St.Footer>
   );
 };

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -13,6 +13,7 @@ interface DetailFooterProp {
   setLike: React.Dispatch<React.SetStateAction<boolean | null>>;
   count: number;
   shippingFee: number;
+  setCartToast: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const DetailFooter = ({
   id,
@@ -22,10 +23,10 @@ const DetailFooter = ({
   setLike,
   count,
   shippingFee,
+  setCartToast,
 }: DetailFooterProp) => {
   const navigate = useNavigate();
   const [toast, setToast] = useState(false);
-  const [cartToast, setCartToast] = useState(false);
 
   const handleClickButton = () => {
     if (like === null) {
@@ -53,10 +54,9 @@ const DetailFooter = ({
         stickerId: id,
         count: count,
       })
-      // 성공 시 navigate
       .then(() => {
-        console.log('카트에 추가 성공');
-        setCartToast(true);
+        console.log('카트에 잘 담김');
+        //setCartToast(true); 이부분 문제
         setSheetOpen(false);
       })
       .catch((err) => {
@@ -129,7 +129,6 @@ const DetailFooter = ({
       <St.Line />
       <St.Like onClick={handleClickLike}>{like ? <IcHeartLight /> : <IcHeartDark />}</St.Like>
       {toast && <Toast setToast={setToast} text='로그인이 필요합니다.' />}
-      {cartToast && <Toast setToast={setCartToast} text='장바구니에 상품이 담겼습니다' />}
     </St.Footer>
   );
 };

--- a/src/components/Detail/DetailFooter.tsx
+++ b/src/components/Detail/DetailFooter.tsx
@@ -57,6 +57,7 @@ const DetailFooter = ({
       .then(() => {
         console.log('카트에 추가 성공');
         setCartToast(true);
+        setSheetOpen(false);
       })
       .catch((err) => {
         console.log(err);

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -47,6 +47,7 @@ const DetailPage = () => {
     response && setLike(response.productLiked);
   }, [response]);
 
+  // test
   useEffect(() => {
     console.log(cartToast);
   }, [cartToast]);
@@ -99,6 +100,7 @@ const DetailPage = () => {
           setLike={setLike}
           discountPrice={response.discountPrice}
           shippingCost={response.shippingCost}
+          setCartToast={setCartToast}
         />
       )}
       {cartToast && <Toast setToast={setCartToast} text='장바구니에 상품이 담겼습니다' />}

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -11,14 +11,15 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useGetSticker from '../libs/hooks/detail/useGetSticker';
 import useGetRelated from '../libs/hooks/detail/useGetRelated';
 import { IcBackDark } from '../assets/icon';
+import Toast from '../common/ToastMessage/Toast';
 
 const DetailPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
 
   const [isSheetOpen, setSheetOpen] = useState(false);
-
   const [like, setLike] = useState<boolean | null>(false);
+  const [cartToast, setCartToast] = useState<boolean>(false);
 
   const renderDetailPageHeader = () => {
     return (
@@ -46,6 +47,10 @@ const DetailPage = () => {
     response && setLike(response.productLiked);
   }, [response]);
 
+  useEffect(() => {
+    console.log(cartToast);
+  }, [cartToast]);
+
   return (
     <PageLayout
       renderHeader={renderDetailPageHeader}
@@ -58,6 +63,7 @@ const DetailPage = () => {
           setLike={setLike}
           count={1}
           shippingFee={3000}
+          setCartToast={setCartToast}
         />
       }
     >
@@ -95,6 +101,7 @@ const DetailPage = () => {
           shippingCost={response.shippingCost}
         />
       )}
+      {cartToast && <Toast setToast={setCartToast} text='장바구니에 상품이 담겼습니다' />}
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #577 

## 💜 작업 내용
- [x] 장바구니 추가 토스트 

## ✅ PR Point
- 아름이가 잘 만들어놨던 Toast 컴포넌트 잘 활용했습니다!! 

## 😡 Trouble Shooting
- 하.... page에서 footer로 넘겨주던 props setCartToast가 `~ is not a function` 에러가 발생했었습니다... 
- 보통 `()=>함수();` 이렇게 작성해줘야하는걸 `함수` 이렇게 작성할 때 해당 에러를 만났었는데 
- typeof 찍으면서.. 타입에러를 열심히 찾다보니 function이 아닌 undefined로 찍히는 것을 발견했습니다 
- 결론은, DetailPage 하위에 있는 DetailFooter와, DetailPage 하위의 DetailBottom 하위의 DetailFooter가 각자 다르게 렌더링되어있었고 제가 클릭액션을 걸었어야하는 부분은 후자였는데, 전자에 계속 걸어주고 있었더라고요 허허 
- 같이 삽질해준 루밍 햄서 감사합니다 

무튼 전달할 말은... **`~ is not a function` TypeError가 발생할 땐 props를 넘겨주지 않아서 undefined 타입 상태여서 뜨는 경우도 있다는 사실** 다들 알고 넘어가세요 ~~ 

## ☀️ 스크린샷 / GIF / 화면 녹화 


https://github.com/TEAM-TATTOUR/tattour-client/assets/81505421/a54a7b58-cc3c-4803-86b6-98d706644e75


