### PR TITLE
[SP1] api 누락된 항목 반영 

### DIFF
--- a/src/components/MyTattoo/MyLike.tsx
+++ b/src/components/MyTattoo/MyLike.tsx
@@ -9,20 +9,22 @@ const MyLike = () => {
     <CustomScrollContainer title={'LIKE'}>
       {!error &&
         !loading &&
-        response.map(({ id, mainImageUrl, name, price, discountPrice, discountRate }) => {
-          return (
-            <SmallTattooCard
-              key={id}
-              id={id}
-              img={mainImageUrl}
-              title={name}
-              price={discountPrice}
-              originalPrice={price}
-              discountRate={discountRate}
-              isCustom={false}
-            />
-          );
-        })}
+        response.map(
+          ({ id, stickerId, mainImageUrl, name, price, discountPrice, discountRate }) => {
+            return (
+              <SmallTattooCard
+                key={id}
+                id={stickerId}
+                img={mainImageUrl}
+                title={name}
+                price={discountPrice}
+                originalPrice={price}
+                discountRate={discountRate}
+                isCustom={false}
+              />
+            );
+          },
+        )}
     </CustomScrollContainer>
   );
 };

--- a/src/libs/hooks/detail/useGetSticker.tsx
+++ b/src/libs/hooks/detail/useGetSticker.tsx
@@ -16,7 +16,8 @@ export interface StickerItemProps {
   shippingCost: number;
   stickerThemes: string[];
   stickerStyles: string[];
-  images: string[];
+  mainImage: string;
+  detailImages: string[];
   productLiked: boolean | null;
 }
 

--- a/src/libs/hooks/useGetCustomDetail.ts
+++ b/src/libs/hooks/useGetCustomDetail.ts
@@ -11,6 +11,7 @@ export interface CustomDetailItemProps {
   styles: string[];
   // default 값 존재
   mainImageUrl: string;
+  // handDrawingImageUrl: string; 누락
   images: string[];
   haveDesign: boolean;
   size?: string;
@@ -21,6 +22,7 @@ export interface CustomDetailItemProps {
   isColored?: boolean;
   isPublic?: boolean;
   isCompleted: boolean;
+  // price: number; 누락
   process?: string;
   viewCount: number;
 }

--- a/src/libs/hooks/useGetLikeSticker.ts
+++ b/src/libs/hooks/useGetLikeSticker.ts
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 export interface LikeStickerProps {
   id: number;
+  stickerId: number;
   name: string;
   price: number;
   discountRate: number;

--- a/src/libs/hooks/useKakaoLogin.tsx
+++ b/src/libs/hooks/useKakaoLogin.tsx
@@ -5,6 +5,7 @@ import api, { setAccessToken } from '../api';
 interface resProps {
   data: {
     data: {
+      // userId: number; 누락
       accessToken: string;
       isUserSignUpCompleted: boolean;
     };

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -65,7 +65,7 @@ const DetailPage = () => {
     >
       {!error && !loading && response && (
         <>
-          <DetailCarousel isCustom={response.isCustom} images={response.images} />
+          <DetailCarousel isCustom={response.isCustom} images={response.detailImages} />
           <DetailInfo response={response} />
         </>
       )}


### PR DESCRIPTION
## 🔥 Related Issues
- resolved #587 

## 💜 작업 내용
- [x] 간단 QA 하면서 오류나는 부분 해결 
- [x] hooks 디렉토리 하위의 서버통신 커스텀 훅 내 interface와 swagger 스키마 대조  

## ✅ PR Point

### 1️⃣
배포서버 **swagger** 참고하면서 작업했습니다 (개발서버는 로그인부터 500에러가 터져서 일단 배포서버 기준으로 작업했습니다) 
[배포서버 swagger](https://dev.tattour.shop/swagger-ui/index.html#/)

### 2️⃣
QA 돌리면서 터지는 부분 찾아서 해결했습니다. 현재 배포계(dev)와 연동시키면 `메인-로그인-상세보기-장바구니-구매하기` 플로우는 아무런 이상 없습니다! 다만, api 통신과 무관한 자잘한 QA 사항들은 남아있어서 (어느부분에서 뒤로가기 하면 터진다던가) 이런 부분은 추후 공유드리겠습니다 

### 3️⃣
QA에서 오류를 뱉지는 않았지만, api hook을 돌면서 swagger와 대조해보는 과정에서 interface에 누락된 프로퍼티가 있는 경우 주석으로 추가해두었습니다. 아래 두 훅 담당자분은 나중에 주석 확인해보시고 불필요한 프로퍼티면 삭제해주세요! 
- useGetCustomDetail
- useKakaoLogin

