### PR TITLE
[SP1] 커스텀 팔레트 정렬 수정, UX 라이팅 수정, 화면 사이즈 변경에 따른 canvas 사이즈 조정 함수 추가

### DIFF
--- a/src/components/Custom/HaveDesign/Reference/Canvas.tsx
+++ b/src/components/Custom/HaveDesign/Reference/Canvas.tsx
@@ -12,25 +12,8 @@ const Canvas: React.FC<CanvasProps> = ({ setCanvasState }: CanvasProps) => {
   const fabricCanvasRef = useRef<fabric.Canvas | null>(null);
   const [containerWidth, setContainerWidth] = useState<number | undefined>(undefined);
 
-  // 화면 비율 바뀌면 캔버스 크기도 그에 맞게 변경해주기
-  useEffect(() => {
-    const handleResize = () => {
-      if (canvasRef.current?.parentElement?.parentElement) {
-        setContainerWidth(canvasRef.current.parentElement.parentElement.clientWidth);
-      }
-    };
-
-    handleResize();
-
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
   // 새 캔버스 만들기 혹은 그려놓은 것이 있다면 유지하면서 캔버스 크기만 조정
-  useEffect(() => {
+  const initializeCanvas = () => {
     if (!canvasRef.current || containerWidth === undefined) return;
 
     if (!fabricCanvasRef.current) {
@@ -54,6 +37,22 @@ const Canvas: React.FC<CanvasProps> = ({ setCanvasState }: CanvasProps) => {
         fabricCanvasRef.current.setDimensions({ width: containerWidth, height: 313 });
       }
     }
+  };
+
+  const handleResize = () => {
+    if (canvasRef.current?.parentElement?.parentElement) {
+      setContainerWidth(canvasRef.current.parentElement.parentElement.clientWidth);
+    }
+  };
+
+  // 화면 비율 바뀌면 캔버스 크기도 그에 맞게 변경해주기
+  useEffect(() => {
+    handleResize();
+    initializeCanvas();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
   }, [containerWidth, setCanvasState]);
 
   //ColorPicker 색상 변경

--- a/src/components/Custom/HaveDesign/Reference/ColorPicker.tsx
+++ b/src/components/Custom/HaveDesign/Reference/ColorPicker.tsx
@@ -110,27 +110,32 @@ const ColorPicker: React.FC<ColorPickerProps> = ({ onColorChange, onBrushChange 
           </St.BrushIconWrapper>
         ))}
       </St.SelectLine>
-      <St.SelectColor>
-        {COLOR_ICONS.map(({ color, Icon }) => (
-          <St.ColorIconWrapper key={color} isSelected={selectedSuggestedColor === color}>
-            <Icon onClick={() => handleChangeSuggestedColor(color)} />
-          </St.ColorIconWrapper>
-        ))}
-        <St.ColorPickerWrapper selectedColor={selectedColor}>
-          <St.ColorPicker
-            src={selectedColor || IcColorRainbow}
-            alt='색상선택'
-            type='color'
-            onChange={handleChange}
-            onClick={handleChangeRainbowColor}
-          />
-          {isColorPickerSelected && (
-            <St.SelectedIcon isSelected={isColorPickerSelected} onClick={handleChangeRainbowColor}>
-              <IcColorSelectedLine />
-            </St.SelectedIcon>
-          )}
-        </St.ColorPickerWrapper>
-      </St.SelectColor>
+      <St.SelectColorWrapper>
+        <St.SelectColor>
+          {COLOR_ICONS.map(({ color, Icon }) => (
+            <St.ColorIconWrapper key={color} isSelected={selectedSuggestedColor === color}>
+              <Icon onClick={() => handleChangeSuggestedColor(color)} />
+            </St.ColorIconWrapper>
+          ))}
+          <St.ColorPickerWrapper selectedColor={selectedColor}>
+            <St.ColorPicker
+              src={selectedColor || IcColorRainbow}
+              alt='색상선택'
+              type='color'
+              onChange={handleChange}
+              onClick={handleChangeRainbowColor}
+            />
+            {isColorPickerSelected && (
+              <St.SelectedIcon
+                isSelected={isColorPickerSelected}
+                onClick={handleChangeRainbowColor}
+              >
+                <IcColorSelectedLine />
+              </St.SelectedIcon>
+            )}
+          </St.ColorPickerWrapper>
+        </St.SelectColor>
+      </St.SelectColorWrapper>
     </St.OptionBox>
   );
 };
@@ -141,13 +146,16 @@ const St = {
   OptionBox: styled.section`
     display: flex;
     width: 100%;
+    justify-content: space-between;
 
-    gap: 4rem;
+    /* gap: 4rem; */
   `,
+
+  SelectColorWrapper: styled.div``,
+
   ColorPickerWrapper: styled.div<ColorPickerWrapperProps>`
     position: relative;
-    /* width: 2.2rem; */
-    width: 3rem;
+    width: 2.2rem;
     height: 2.2rem;
     border-radius: 0.5rem;
 
@@ -172,6 +180,7 @@ const St = {
     opacity: 0;
     cursor: pointer;
   `,
+
   SelectLine: styled.div`
     display: flex;
     justify-content: center;
@@ -188,8 +197,8 @@ const St = {
   `,
   SelectColor: styled.div`
     display: flex;
-    justify-content: center;
-    gap: 1.8rem;
+    justify-content: space-between;
+
     align-items: center;
     padding: 0;
 

--- a/src/components/Custom/HaveDesign/Reference/ColorPicker.tsx
+++ b/src/components/Custom/HaveDesign/Reference/ColorPicker.tsx
@@ -147,8 +147,6 @@ const St = {
     display: flex;
     width: 100%;
     justify-content: space-between;
-
-    /* gap: 4rem; */
   `,
 
   SelectColorWrapper: styled.div``,

--- a/src/components/Custom/HaveDesign/Reference/CustomImageAttach.tsx
+++ b/src/components/Custom/HaveDesign/Reference/CustomImageAttach.tsx
@@ -196,7 +196,7 @@ const CustomImageAttach: React.FC<CustomImageAttachProps> = ({
           className={drawingImageUrl ? 'disabled' : ''}
         >
           <IcDraw />
-          대충 그리기
+          간단 스케치
         </St.ReferenceButton>
       </St.ButtonWrapper>
       {toast && <Toast setToast={setToast} text='이미지를 3장 이상 첨부할 수 없습니다' />}

--- a/src/components/Custom/HaveDesign/Reference/CustomReference.tsx
+++ b/src/components/Custom/HaveDesign/Reference/CustomReference.tsx
@@ -60,7 +60,6 @@ const St = {
   PageWrapper: styled.div`
     display: flex;
     flex-direction: column;
-    /* align-items: center; */
     min-height: calc(100dvh - 13.6rem);
     margin-bottom: 7rem;
   `,

--- a/src/components/Custom/HaveDesign/Reference/PaintBottomHeader.tsx
+++ b/src/components/Custom/HaveDesign/Reference/PaintBottomHeader.tsx
@@ -12,7 +12,7 @@ const PaintBottomHeader = ({ onClose }: PaintBottomHeaderProps) => {
 
   return (
     <St.HeaderWrapper>
-      <St.PaintTitle>대충 그려보기</St.PaintTitle>
+      <St.PaintTitle>간단 스케치</St.PaintTitle>
       <St.SheetClose>
         <IcCancelDark onClick={handleClose} />
       </St.SheetClose>

--- a/src/components/Custom/HaveDesign/Reference/PaintBottomSheet.tsx
+++ b/src/components/Custom/HaveDesign/Reference/PaintBottomSheet.tsx
@@ -27,7 +27,7 @@ const PaintBottomSheet = ({
   const onClickSubmitImage = () => {
     // 캔버스 저장 후 전달
     if (!canvasState) return;
-    setDrawingImageUrl(canvasState?.toDataURL());
+    setDrawingImageUrl(canvasState.toDataURL());
     setBottomOpen(false);
   };
 
@@ -63,9 +63,9 @@ const St = {
     width: 100%;
   `,
   ContentWrapper: styled.div`
-    height: 100%;
-    width: 100%;
-    overflow-y: auto;
+    /* height: 100%;
+    width: 100%; */
+    /* overflow-y: auto; */
   `,
   Footer: styled.footer`
     display: flex;

--- a/src/components/Custom/HaveDesign/Reference/PaintBottomSheet.tsx
+++ b/src/components/Custom/HaveDesign/Reference/PaintBottomSheet.tsx
@@ -82,6 +82,8 @@ const St = {
 };
 
 const CustomSheet = styled(Sheet)`
+  max-width: 43rem;
+  margin: 0 auto;
   .react-modal-sheet-backdrop {
     background-color: rgba(0, 0, 0, 0.6) !important;
   }

--- a/src/components/Custom/HaveDesign/Reference/PaintBottomSheet.tsx
+++ b/src/components/Custom/HaveDesign/Reference/PaintBottomSheet.tsx
@@ -62,11 +62,7 @@ const St = {
     padding: 2.5rem 2rem 2.8rem 2rem;
     width: 100%;
   `,
-  ContentWrapper: styled.div`
-    /* height: 100%;
-    width: 100%; */
-    /* overflow-y: auto; */
-  `,
+  ContentWrapper: styled.div``,
   Footer: styled.footer`
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #issue_number

## 💜 작업 내용
- [x] 캔버스 생성 코드 수정
- [x] UX 라이팅 수정
- [x] 브러시 커스텀 팔레트 정렬 조정

## ✅ PR Point
- 화면 사이즈에 따라 캔버스 사이즈가 달라지도록 수정했습니다. 높이는 고정이고, 너비는 화면의 가로 너비가 넓어지면 넓어지도록 수정했는데 높이도 화면 사이즈에 따라 달라지는 것이 좋을지 고민돼서 의견 부탁드려요! 화면 사이즈가 달라지면 `canvas` 생성할 때 새롭게 넓어진 너비의 캔버스를 생성하는 함수를 추가했습니다.

```typescript
  const handleResize = () => {
    if (canvasRef.current?.parentElement?.parentElement) {
      setContainerWidth(canvasRef.current.parentElement.parentElement.clientWidth);
    }
  };
```
- 대충 그리기라고 잘못 작성되어 있던 UX 라이팅 수정 완료했습니다.
- 브러시 커스텀 팔레트 배열을 스크롤이 생기지 않도록 `space-between`으로 조정했습니다.

## 😡 Trouble Shooting
- 기존에 있던 `canvas.dispose()`를 삭제해도 그림 그리기 완료를 누르면 컴포넌트가 unmount됨에 따라 그림이 초기화되어서 해당 코드를 삭제했습니다.
- canvas wrapper의 width에 맞게 canvas가 생성되지 않고, 그림 그릴 수 있는 영역이 더 길게 잡히는 문제가 있었는데, 제가 원하는 상위 컴포넌트의 width를 참조할 수 있도록 수정했고, resize에 맞게 달라져야 해서 `useState`를 추가했습니다.
```typescript
      setContainerWidth(canvasRef.current.parentElement.parentElement.clientWidth);
``` 
## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/TEAM-TATTOUR/tattour-client/assets/92876819/c650b346-962a-408d-8d01-3405c94f5697


## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)