### PR TITLE
[S1]  인증번호 요청 버튼 클릭 시, n초 간 버튼 비활성화

### DIFF
--- a/src/components/Register/RegisterPhoneNumForm.tsx
+++ b/src/components/Register/RegisterPhoneNumForm.tsx
@@ -27,6 +27,7 @@ interface usePatchProfileProps {
 const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
   const navigate = useNavigate();
   const MINUTES_IN_MS = 5 * 60 * 1000;
+  const [isDisabled, setIsDisabled] = useState(false);
   const [toast, setToast] = useState(false);
   const [isTimeout, setIsTimeout] = useState(false);
   const [inputData, setInputData] = useState({
@@ -86,12 +87,18 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
           phoneNumber: `${phoneNum}`,
         })
         .then(() => {
+          setIsDisabled(true);
           dispatch({ type: 'SHOW_CERTIFICATION_FORM' });
           setToast(true);
           setIsTimeout(false);
         })
         .catch(() => {
           navigate('/error');
+        })
+        .finally(() => {
+          setTimeout(() => {
+            setIsDisabled(false);
+          }, 7000);
         });
     }
     dispatch({ type: 'HIDE_CERTIFICATION_FORM' });
@@ -149,6 +156,7 @@ const RegisterPhoneNumForm = ({ setStep }: RegisterPhoneNumFormProps) => {
         <St.SendMessageBtn
           type='button'
           $length={phoneNum.length}
+          disabled={isDisabled}
           onClick={handleClickSendMessageBtn}
         >
           {registerState.isVisible && phoneNum.length === 11 ? '재인증' : '인증하기'}
@@ -219,7 +227,7 @@ const St = {
     }
   `,
 
-  SendMessageBtn: styled.button<{ $length: number }>`
+  SendMessageBtn: styled.button<{ $length: number; disabled: boolean }>`
     width: 9.2rem;
     height: 4.5rem;
 
@@ -228,8 +236,8 @@ const St = {
 
     color: ${({ theme }) => theme.colors.white};
 
-    background-color: ${({ theme, $length }) =>
-      $length === 11 ? theme.colors.gray7 : theme.colors.gray3};
+    background-color: ${({ theme, $length, disabled }) =>
+      !disabled && $length === 11 ? theme.colors.gray7 : theme.colors.gray3};
 
     ${({ theme }) => theme.fonts.title_semibold_16};
   `,


### PR DESCRIPTION
## 🔥 Related Issues
resolved #621 

## 💜 작업 내용
- [x] 인증번호 요청 버튼 클릭 시, n초 간 버튼 비활성화

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - 인증번호 요청 버튼이 계속해서 눌리게 되면, 서버 통신도 그만큼 이뤄지기 때문에 인증번호 문자 요금도 계속 청구
  - setTimeout과 isDisabled라는 상태를 만들어서 해결했습니다.
    - 버튼 클릭 후, 서버 통신이 제대로 이뤄졌다면 setIsDisabled(true) -> 통신이 모두 끝난 이후 setTimeout 실행
    - setTimeout 내부 -> setIsDisabled(false)로 바꿔줌.
    - 시간을 체크해보니 문자가 오기까지 대략 5초 내외의 시간이 걸림 + 문자가 도착하기 전에 버튼 비활성화가 풀리면 안된다고 판단하여 7초의 시간제한을 줬습니다. (테스트 결과 10초는 너무 길다고 느껴짐)

## ☀️ 스크린샷 / GIF / 화면 녹화 
- 여러 번 버튼 클릭했지만, 비활성화 되어있기 때문에 문자는 하나만 옴 !


https://github.com/TEAM-TATTOUR/tattour-client/assets/80264647/2938d711-88b8-46c4-8a21-28329c72c06f

