### PR TITLE
[S1] 상세페이지 뒤로가기 위치 변경 

### DIFF
--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -27,7 +27,7 @@ const DetailPage = () => {
         leftSection={
           <IcBackDark
             onClick={() => {
-              navigate('/list');
+              navigate(-1);
             }}
           />
         }


### PR DESCRIPTION
## 🔥 Related Issues
resolved #624 

## 💜 작업 내용
- 상세페이지 뒤로가기 시 기존에는 무조건 list로 이동시켰는데, 메인뷰orlist 중 이전 페이지로 돌아가는 것으로 수정했습니다 

## ✅ PR Point
```tsx
          <IcBackDark
            onClick={() => {
              navigate(-1);  //여기
            }}
          />
```